### PR TITLE
Refine Pilatta logo wordmark connection

### DIFF
--- a/components/shared/brand-logo.tsx
+++ b/components/shared/brand-logo.tsx
@@ -8,7 +8,7 @@ interface BrandLogoProps {
 
 export function BrandLogo({ className, compact = false, light = false }: BrandLogoProps) {
   return (
-    <span className={cn('inline-flex items-center', compact ? 'gap-1.5' : 'gap-2', className)}>
+    <span className={cn('inline-flex items-center', compact ? 'gap-1' : 'gap-1.5', className)}>
       <span
         className={cn(
           'relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-[1.4rem] border shadow-lg transition-transform duration-300 group-hover:scale-[1.03]',
@@ -26,7 +26,7 @@ export function BrandLogo({ className, compact = false, light = false }: BrandLo
         <span
           className={cn(
             'pointer-events-none absolute top-1/2 h-px -translate-y-1/2 rounded-full opacity-70',
-            compact ? '-left-2.5 w-4' : '-left-3.5 w-6',
+            compact ? '-left-2 w-3.5' : '-left-3 w-5',
             light
               ? 'bg-gradient-to-r from-white/0 via-white/75 to-white/10'
               : 'bg-gradient-to-r from-primary/0 via-primary/65 to-primary/5'
@@ -34,8 +34,8 @@ export function BrandLogo({ className, compact = false, light = false }: BrandLo
         />
         <span
           className={cn(
-            'inline-block font-sans font-semibold leading-none tracking-[0.08em]',
-            compact ? '-ml-1 text-[0.98rem]' : '-ml-1.5 text-[1.12rem] md:text-[1.24rem]',
+            'inline-block font-serif font-bold leading-none tracking-[0.03em]',
+            compact ? '-ml-2 text-[1.02rem]' : '-ml-2.5 text-[1.18rem] md:text-[1.32rem]',
             light ? 'text-white' : 'text-foreground'
           )}
         >

--- a/components/shared/brand-logo.tsx
+++ b/components/shared/brand-logo.tsx
@@ -8,7 +8,7 @@ interface BrandLogoProps {
 
 export function BrandLogo({ className, compact = false, light = false }: BrandLogoProps) {
   return (
-    <span className={cn('inline-flex items-center', compact ? 'gap-1' : 'gap-1.5', className)}>
+    <span className={cn('inline-flex items-center', compact ? 'gap-2' : 'gap-2.5', className)}>
       <span
         className={cn(
           'relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-[1.4rem] border shadow-lg transition-transform duration-300 group-hover:scale-[1.03]',
@@ -22,25 +22,14 @@ export function BrandLogo({ className, compact = false, light = false }: BrandLo
         <span className="relative font-sans text-[1.05em] font-bold tracking-[-0.06em]">P</span>
       </span>
 
-      <span className="relative inline-flex items-center">
-        <span
-          className={cn(
-            'pointer-events-none absolute top-1/2 h-px -translate-y-1/2 rounded-full opacity-70',
-            compact ? '-left-2 w-3.5' : '-left-3 w-5',
-            light
-              ? 'bg-gradient-to-r from-white/0 via-white/75 to-white/10'
-              : 'bg-gradient-to-r from-primary/0 via-primary/65 to-primary/5'
-          )}
-        />
-        <span
-          className={cn(
-            'inline-block font-serif font-bold leading-none tracking-[0.03em]',
-            compact ? '-ml-2 text-[1.02rem]' : '-ml-2.5 text-[1.18rem] md:text-[1.32rem]',
-            light ? 'text-white' : 'text-foreground'
-          )}
-        >
-          ilatta
-        </span>
+      <span
+        className={cn(
+          'inline-block font-serif font-semibold leading-none tracking-[0.04em]',
+          compact ? 'text-[1.05rem]' : 'text-[1.28rem] md:text-[1.42rem]',
+          light ? 'text-white' : 'text-foreground'
+        )}
+      >
+        Pilatta
       </span>
     </span>
   )

--- a/components/shared/brand-logo.tsx
+++ b/components/shared/brand-logo.tsx
@@ -34,15 +34,10 @@ export function BrandLogo({ className, compact = false, light = false }: BrandLo
         />
         <span
           className={cn(
-            'inline-block leading-none tracking-[0.02em]',
-            compact ? '-ml-1 text-[1.05rem]' : '-ml-1.5 text-[1.3rem] md:text-[1.45rem]',
+            'inline-block font-sans font-semibold leading-none tracking-[0.08em]',
+            compact ? '-ml-1 text-[0.98rem]' : '-ml-1.5 text-[1.12rem] md:text-[1.24rem]',
             light ? 'text-white' : 'text-foreground'
           )}
-          style={{
-            fontFamily: 'var(--font-serif)',
-            fontStyle: 'italic',
-            fontWeight: 600,
-          }}
         >
           ilatta
         </span>

--- a/components/shared/brand-logo.tsx
+++ b/components/shared/brand-logo.tsx
@@ -8,7 +8,7 @@ interface BrandLogoProps {
 
 export function BrandLogo({ className, compact = false, light = false }: BrandLogoProps) {
   return (
-    <span className={cn('inline-flex items-center', compact ? 'gap-2' : 'gap-3', className)}>
+    <span className={cn('inline-flex items-center', compact ? 'gap-1.5' : 'gap-2', className)}>
       <span
         className={cn(
           'relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-[1.4rem] border shadow-lg transition-transform duration-300 group-hover:scale-[1.03]',
@@ -22,14 +22,30 @@ export function BrandLogo({ className, compact = false, light = false }: BrandLo
         <span className="relative font-sans text-[1.05em] font-bold tracking-[-0.06em]">P</span>
       </span>
 
-      <span
-        className={cn(
-          'font-sans font-semibold tracking-[0.18em] uppercase leading-none',
-          compact ? 'text-[0.95rem]' : 'text-[1.05rem] md:text-[1.2rem]',
-          light ? 'text-white' : 'text-foreground'
-        )}
-      >
-        <span className="-ml-1 inline-block">ilatta</span>
+      <span className="relative inline-flex items-center">
+        <span
+          className={cn(
+            'pointer-events-none absolute top-1/2 h-px -translate-y-1/2 rounded-full opacity-70',
+            compact ? '-left-2.5 w-4' : '-left-3.5 w-6',
+            light
+              ? 'bg-gradient-to-r from-white/0 via-white/75 to-white/10'
+              : 'bg-gradient-to-r from-primary/0 via-primary/65 to-primary/5'
+          )}
+        />
+        <span
+          className={cn(
+            'inline-block leading-none tracking-[0.02em]',
+            compact ? '-ml-1 text-[1.05rem]' : '-ml-1.5 text-[1.3rem] md:text-[1.45rem]',
+            light ? 'text-white' : 'text-foreground'
+          )}
+          style={{
+            fontFamily: 'var(--font-serif)',
+            fontStyle: 'italic',
+            fontWeight: 600,
+          }}
+        >
+          ilatta
+        </span>
       </span>
     </span>
   )


### PR DESCRIPTION
### Motivation
- Make the logo read as a single, flowing word by creating a smoother visual transition from the badge `P` to the `ilatta` wordmark.
- Improve the compact and light variants so the badge and wordmark feel visually connected across sizes and themes.

### Description
- Tighten the spacing between the badge and the wordmark by changing the wrapper gap from `gap-3`/`gap-2` to `gap-2`/`gap-1.5` for regular and compact respectively in `components/shared/brand-logo.tsx`.
- Add an absolute, subtle gradient “connector” element between the icon and the `ilatta` lettering with separate gradients for the `light` and default themes to visually bridge the two parts.
- Restyle the `ilatta` wordmark to an italic serif treatment with adjusted tracking, left offset and size (`-ml-1.5` / `-ml-1` and larger text sizes) and set font weight to 600 so the mark reads more cohesive and elegant.
- Keep the badge markup and overall structure but adjust spacing and typography so both compact and full variants behave consistently.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and it failed due to a missing ESLint flat config (`eslint.config.(js|mjs|cjs)`), which is an existing repository configuration issue unrelated to the logo change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bfe184c234832597f6614ec8a2e45e)