### PR TITLE
Align pricing card headers

### DIFF
--- a/components/sections/pricing-section.tsx
+++ b/components/sections/pricing-section.tsx
@@ -42,15 +42,10 @@ function PricingCard({ plan, index }: { plan: PricingPlan; index: number }) {
         </div>
       )}
 
-      <div className="mb-6 pt-2">
+      <div className="mb-6 flex min-h-14 items-start pt-2">
         <h3 className="font-serif text-xl font-semibold text-foreground">
           {plan.name}
         </h3>
-        {plan.sessions > 1 && plan.sessions < 999 && (
-          <p className="text-sm text-muted-foreground mt-1">
-            {plan.sessions} занятий
-          </p>
-        )}
       </div>
 
       {/* Price */}


### PR DESCRIPTION
### Motivation
- Сделать так, чтобы блок с ценой начинался на одном уровне во всех карточках раздела «Стоимость занятий», убрав смещение у карточек с количеством занятий (например, на 8 и 12 занятий). 

### Description
- В файле `components/sections/pricing-section.tsx` удалил условный рендеринг строки с количеством занятий и добавил фиксированную высоту для контейнера заголовка, изменив класс на `mb-6 flex min-h-14 items-start pt-2`, чтобы заголовки занимали одинаковое пространство и выровняли блоки с ценой. 

### Testing
- Запущена сборка с `npm run build`, которая успешно скомпилировала проект; lint с `npm run lint` не прошёл из-за отсутствия конфигурации ESLint v9 (`eslint.config.(js|mjs|cjs)`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bfe8de4b8c8325a8a3e749446b1cd6)