### PR TITLE
Mobile-first redesign: compact hero, horizontal snap rows & tightened spacing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -120,6 +120,9 @@
   html, body {
     @apply overflow-x-clip;
   }
+  html {
+    scroll-behavior: smooth;
+  }
   body {
     @apply bg-background text-foreground overflow-x-clip;
     font-feature-settings: 'liga' 1, 'kern' 1;
@@ -129,5 +132,18 @@
 @layer utilities {
   .text-brand-balance {
     text-wrap: balance;
+  }
+
+  .mobile-snap-row {
+    @apply -mx-4 flex snap-x snap-mandatory gap-4 overflow-x-auto px-4 pb-2 sm:mx-0 sm:grid sm:snap-none sm:overflow-visible sm:px-0 sm:pb-0;
+    scrollbar-width: none;
+  }
+
+  .mobile-snap-row::-webkit-scrollbar {
+    display: none;
+  }
+
+  .mobile-snap-card {
+    @apply w-[85vw] max-w-sm shrink-0 snap-center sm:w-auto sm:max-w-none sm:shrink sm:snap-start;
   }
 }

--- a/components/layout/section-wrapper.tsx
+++ b/components/layout/section-wrapper.tsx
@@ -52,8 +52,8 @@ export function SectionWrapper({
   }
 
   const paddingClasses = {
-    default: 'py-16 md:py-24',
-    large: 'py-20 md:py-32',
+    default: 'py-12 md:py-24',
+    large: 'py-16 md:py-32',
     none: '',
   }
 

--- a/components/sections/about-section.tsx
+++ b/components/sections/about-section.tsx
@@ -31,7 +31,7 @@ export function AboutSection() {
 
   return (
     <SectionWrapper id="about" background="default" animate={false}>
-      <div ref={sectionRef} className="grid gap-12 lg:grid-cols-2 lg:gap-20 items-center">
+      <div ref={sectionRef} className="grid items-center gap-8 lg:grid-cols-2 lg:gap-20">
         {/* Image */}
         <div 
           className={cn(
@@ -39,7 +39,7 @@ export function AboutSection() {
             isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-12'
           )}
         >
-          <div className="relative">
+          <div className="relative mx-auto max-w-sm lg:max-w-none">
             <ImagePlaceholder
               src={trainer.photoUrl}
               alt={`Тренер ${trainer.name}`}
@@ -53,7 +53,7 @@ export function AboutSection() {
           </div>
           
           {/* Floating card */}
-          <div className="absolute bottom-4 right-4 bg-card rounded-2xl shadow-xl p-4 md:bottom-8 md:right-[-3rem] md:p-6 border border-border/50">
+          <div className="absolute bottom-3 right-3 rounded-2xl border border-border/50 bg-card p-3 shadow-xl md:bottom-8 md:right-[-3rem] md:p-6">
             <div className="flex items-center gap-3">
               <div className="h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center">
                 <Award className="h-6 w-6 text-primary" />
@@ -73,7 +73,7 @@ export function AboutSection() {
             isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-12'
           )}
         >
-          <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 mb-6">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 md:mb-6">
             <span className="text-sm font-semibold text-primary">О тренере</span>
           </div>
           
@@ -81,27 +81,27 @@ export function AboutSection() {
             Привет, я {trainer.name}
           </h2>
           
-          <p className="mt-2 text-xl text-muted-foreground">
+          <p className="mt-2 text-lg text-muted-foreground md:text-xl">
             Ваш тренер по пилатесу
           </p>
 
-          <p className="mt-6 text-lg text-muted-foreground leading-relaxed">
+          <p className="mt-5 text-base leading-relaxed text-muted-foreground md:mt-6 md:text-lg">
             {trainer.bio}
           </p>
 
           {/* Stats */}
-          <div className="mt-8 grid grid-cols-3 gap-4">
-            <div className="text-center p-4 rounded-xl bg-muted/50">
+          <div className="mt-6 grid grid-cols-1 gap-3 sm:mt-8 sm:grid-cols-3 sm:gap-4">
+            <div className="rounded-xl bg-muted/50 p-4 text-center">
               <Clock className="h-5 w-5 text-primary mx-auto mb-2" />
               <p className="text-xs text-muted-foreground">Опыт</p>
               <p className="font-semibold text-foreground">{trainer.experience}</p>
             </div>
-            <div className="text-center p-4 rounded-xl bg-muted/50">
+            <div className="rounded-xl bg-muted/50 p-4 text-center">
               <Award className="h-5 w-5 text-primary mx-auto mb-2" />
               <p className="text-xs text-muted-foreground">Тренер</p>
               <p className="font-semibold text-foreground">{trainer.trainerExperience}</p>
             </div>
-            <div className="text-center p-4 rounded-xl bg-muted/50">
+            <div className="rounded-xl bg-muted/50 p-4 text-center">
               <Users className="h-5 w-5 text-primary mx-auto mb-2" />
               <p className="text-xs text-muted-foreground">Клиенты</p>
               <p className="font-semibold text-foreground">500+</p>

--- a/components/sections/benefits-section.tsx
+++ b/components/sections/benefits-section.tsx
@@ -51,12 +51,12 @@ export function BenefitsSection() {
         subtitle="Метод, который трансформирует тело и улучшает качество жизни"
       />
 
-      <div ref={sectionRef} className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div ref={sectionRef} className="mobile-snap-row lg:grid lg:grid-cols-3">
         {benefits.map((benefit, index) => (
           <div
             key={benefit.id}
             className={cn(
-              'group relative flex flex-col rounded-2xl bg-card p-8 shadow-sm border border-border/50 transition-all duration-500 hover:shadow-xl hover:shadow-primary/5 hover:-translate-y-1',
+              'mobile-snap-card group relative flex flex-col rounded-2xl border border-border/50 bg-card p-6 shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl hover:shadow-primary/5 md:p-8',
               isVisible
                 ? 'opacity-100 translate-y-0'
                 : 'opacity-0 translate-y-8'
@@ -69,13 +69,13 @@ export function BenefitsSection() {
             <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-primary/5 via-transparent to-accent/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
             
             <div className="relative z-10">
-              <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 text-primary transition-all duration-300 group-hover:scale-110 group-hover:from-primary group-hover:to-primary/80 group-hover:text-primary-foreground">
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 text-primary transition-all duration-300 group-hover:scale-110 group-hover:from-primary group-hover:to-primary/80 group-hover:text-primary-foreground md:mb-5 md:h-14 md:w-14">
                 {iconMap[benefit.icon] || <Sparkles className="h-6 w-6" />}
               </div>
-              <h3 className="font-serif text-xl font-semibold text-foreground">
+              <h3 className="font-serif text-lg font-semibold text-foreground md:text-xl">
                 {benefit.title}
               </h3>
-              <p className="mt-3 text-muted-foreground leading-relaxed">
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground md:text-base">
                 {benefit.description}
               </p>
             </div>

--- a/components/sections/contact-section.tsx
+++ b/components/sections/contact-section.tsx
@@ -53,7 +53,7 @@ export function ContactSection() {
           subtitle="Оставьте заявку, и мы свяжемся с вами в ближайшее время"
         />
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:gap-16">
+        <div className="grid gap-8 lg:grid-cols-2 lg:gap-16">
           {/* Contact info */}
           <div 
             className={cn(
@@ -61,18 +61,18 @@ export function ContactSection() {
               isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'
             )}
           >
-            <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 mb-6">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 md:mb-6">
               <span className="text-sm font-semibold text-primary">Контакты</span>
             </div>
             
-            <h3 className="font-serif text-2xl font-semibold text-foreground mb-6">
+            <h3 className="mb-5 font-serif text-2xl font-semibold text-foreground md:mb-6">
               Свяжитесь с нами
             </h3>
 
             <div className="space-y-4">
               <a
                 href={`tel:${studioInfo.phone}`}
-                className="group flex items-center gap-4 rounded-2xl border border-border/50 bg-card p-5 transition-all duration-300 hover:border-primary/30 hover:shadow-xl hover:-translate-y-0.5"
+                className="group flex items-center gap-3 rounded-2xl border border-border/50 bg-card p-4 transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-xl md:gap-4 md:p-5"
               >
                 <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 transition-all duration-300 group-hover:from-primary group-hover:to-primary/80">
                   <Phone className="h-6 w-6 text-primary group-hover:text-primary-foreground transition-colors" />
@@ -86,7 +86,7 @@ export function ContactSection() {
 
               <a
                 href={`mailto:${studioInfo.email}`}
-                className="group flex items-center gap-4 rounded-2xl border border-border/50 bg-card p-5 transition-all duration-300 hover:border-primary/30 hover:shadow-xl hover:-translate-y-0.5"
+                className="group flex items-center gap-3 rounded-2xl border border-border/50 bg-card p-4 transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-xl md:gap-4 md:p-5"
               >
                 <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 transition-all duration-300 group-hover:from-primary group-hover:to-primary/80">
                   <Mail className="h-6 w-6 text-primary group-hover:text-primary-foreground transition-colors" />
@@ -98,7 +98,7 @@ export function ContactSection() {
                 <ArrowRight className="ml-auto h-5 w-5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-all group-hover:translate-x-1" />
               </a>
 
-              <div className="flex items-center gap-4 rounded-2xl border border-border/50 bg-card p-5">
+              <div className="flex items-center gap-3 rounded-2xl border border-border/50 bg-card p-4 md:gap-4 md:p-5">
                 <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-gradient-to-br from-primary/20 to-primary/5">
                   <MapPin className="h-6 w-6 text-primary" />
                 </div>
@@ -134,7 +134,7 @@ export function ContactSection() {
           {/* Form */}
           <div 
             className={cn(
-              'rounded-3xl bg-card border border-border/50 p-8 md:p-10 shadow-xl transition-all duration-700 delay-200',
+              'rounded-3xl border border-border/50 bg-card p-5 shadow-xl transition-all duration-700 delay-200 md:p-10',
               isVisible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-8'
             )}
           >

--- a/components/sections/faq-section.tsx
+++ b/components/sections/faq-section.tsx
@@ -36,7 +36,7 @@ export function FAQSection() {
         </Accordion>
 
         {/* CTA */}
-        <div className="mt-12 rounded-lg bg-card p-8 text-center shadow-sm">
+        <div className="mt-10 rounded-2xl bg-card p-6 text-center shadow-sm md:mt-12 md:p-8">
           <h3 className="font-serif text-xl font-medium text-foreground">
             Остались вопросы?
           </h3>

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -23,9 +23,9 @@ export function HeroSection() {
   }, [])
 
   return (
-    <section id="hero" className="relative min-h-screen overflow-hidden">
+    <section id="hero" className="relative overflow-hidden bg-background pb-10 pt-24 md:min-h-screen md:pb-0 md:pt-0">
       {/* Background Image with overlay */}
-      <div className="absolute inset-0 z-0">
+      <div className="absolute inset-0 z-0 hidden md:block">
         <ImagePlaceholder
           src="/images/hero.jpg"
           alt="Pilatta студия пилатеса"
@@ -38,12 +38,30 @@ export function HeroSection() {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl items-center px-4 sm:px-6 lg:px-8">
-        <div ref={contentRef} className="w-full max-w-2xl py-32">
+      <div className="relative z-10 mx-auto flex max-w-7xl items-center px-4 sm:px-6 lg:px-8 md:min-h-screen">
+        <div ref={contentRef} className="w-full py-2 md:max-w-2xl md:py-32">
           {/* Glass card for text */}
-          <div className="rounded-2xl bg-card/80 backdrop-blur-md border border-border/50 p-8 md:p-12 shadow-2xl">
+          <div className="overflow-hidden rounded-[2rem] border border-border/50 bg-card/95 p-5 shadow-xl shadow-primary/10 backdrop-blur-md md:bg-card/80 md:p-12 md:shadow-2xl">
+            <div className="relative -mx-5 -mt-5 mb-6 aspect-[5/4] overflow-hidden md:hidden">
+              <ImagePlaceholder
+                src="/images/hero.jpg"
+                alt="Pilatta студия пилатеса"
+                className="h-full w-full"
+                fill
+                priority
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-background via-background/10 to-transparent" />
+              <div className="absolute inset-x-4 bottom-4 flex flex-wrap gap-2">
+                <span className="rounded-full bg-background/90 px-3 py-1.5 text-xs font-semibold text-foreground shadow-sm backdrop-blur">
+                  Пилатес для осанки и спины
+                </span>
+                <span className="rounded-full bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground shadow-sm">
+                  Центр Москвы
+                </span>
+              </div>
+            </div>
             {/* Tagline */}
-            <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 mb-6">
+            <div className="mb-5 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3.5 py-2 md:mb-6 md:px-4">
               <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
               <span className="text-sm font-semibold uppercase tracking-wider text-primary">
                 Персональные тренировки
@@ -58,14 +76,14 @@ export function HeroSection() {
             </h1>
 
             {/* Subtitle */}
-            <p className="mt-6 text-lg text-muted-foreground md:text-xl leading-relaxed text-pretty">
+            <p className="mt-4 text-base leading-relaxed text-muted-foreground md:mt-6 md:text-xl text-pretty">
               Пилатес с сертифицированным тренером для здоровья спины, 
               красивой осанки и гармонии тела. 15 лет опыта, индивидуальный подход.
             </p>
 
             {/* CTA */}
-            <div className="mt-8 flex items-center gap-4 flex-wrap">
-              <CTAButton size="lg" className="shadow-lg shadow-primary/25 shrink-0" />
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4 md:mt-8">
+              <CTAButton size="lg" className="w-full shrink-0 shadow-lg shadow-primary/25 sm:w-auto" />
               <a
                 href="#about"
                 className="group inline-flex items-center gap-2 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground shrink-0"
@@ -80,18 +98,18 @@ export function HeroSection() {
             </div>
 
             {/* Stats */}
-            <div className="mt-10 pt-8 border-t border-border/50 grid grid-cols-3 gap-6">
-              <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">15+</div>
-                <div className="text-sm text-muted-foreground mt-1">лет опыта</div>
+            <div className="mt-8 grid grid-cols-3 gap-3 border-t border-border/50 pt-6 md:mt-10 md:gap-6 md:pt-8">
+              <div className="rounded-2xl bg-muted/60 p-3 md:bg-transparent md:p-0">
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">15+</div>
+                <div className="mt-1 text-xs text-muted-foreground md:text-sm">лет опыта</div>
               </div>
-              <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">1000+</div>
-                <div className="text-sm text-muted-foreground mt-1">учеников</div>
+              <div className="rounded-2xl bg-muted/60 p-3 md:bg-transparent md:p-0">
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">1000+</div>
+                <div className="mt-1 text-xs text-muted-foreground md:text-sm">учеников</div>
               </div>
-              <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">10+</div>
-                <div className="text-sm text-muted-foreground mt-1">программ</div>
+              <div className="rounded-2xl bg-muted/60 p-3 md:bg-transparent md:p-0">
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">10+</div>
+                <div className="mt-1 text-xs text-muted-foreground md:text-sm">программ</div>
               </div>
             </div>
           </div>

--- a/components/sections/method-section.tsx
+++ b/components/sections/method-section.tsx
@@ -72,16 +72,16 @@ export function MethodSection() {
         {/* Philosophy quote */}
         <div 
           className={cn(
-            'mx-auto mb-16 max-w-3xl relative transition-all duration-700',
+            'relative mx-auto mb-10 max-w-3xl transition-all duration-700 md:mb-16',
             isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
           )}
         >
-          <div className="absolute -top-6 left-8 text-primary/20">
+          <div className="absolute -top-4 left-4 text-primary/20 md:-top-6 md:left-8">
             <Quote className="h-16 w-16" />
           </div>
-          <div className="rounded-2xl bg-card border border-border/50 p-8 md:p-12 shadow-lg relative">
+          <div className="relative rounded-2xl border border-border/50 bg-card p-5 shadow-lg md:p-12">
             <blockquote className="text-center">
-              <p className="font-serif text-xl text-foreground md:text-2xl leading-relaxed">
+              <p className="font-serif text-lg leading-relaxed text-foreground md:text-2xl">
                 {trainer.philosophy}
               </p>
               <footer className="mt-6 flex items-center justify-center gap-3">
@@ -94,12 +94,12 @@ export function MethodSection() {
         </div>
 
         {/* Principles grid */}
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mobile-snap-row lg:grid lg:grid-cols-3">
           {principles.map((principle, index) => (
             <div
               key={principle.number}
               className={cn(
-                'group relative rounded-2xl border border-border/50 bg-card p-8 transition-all duration-500 hover:border-primary/30 hover:shadow-xl hover:-translate-y-1',
+                'mobile-snap-card group relative rounded-2xl border border-border/50 bg-card p-6 transition-all duration-500 hover:border-primary/30 hover:shadow-xl hover:-translate-y-1 md:p-8',
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
               )}
               style={{ transitionDelay: isVisible ? `${index * 100}ms` : '0ms' }}

--- a/components/sections/pricing-section.tsx
+++ b/components/sections/pricing-section.tsx
@@ -15,7 +15,7 @@ function PricingCard({ plan, index }: { plan: PricingPlan; index: number }) {
   return (
     <div
       className={cn(
-        'relative flex flex-col rounded-2xl border bg-card p-6 md:p-8 transition-all duration-500 hover:-translate-y-1',
+        'mobile-snap-card relative flex flex-col rounded-2xl border bg-card p-5 transition-all duration-500 hover:-translate-y-1 md:p-8',
         plan.isPopular 
           ? 'border-primary shadow-2xl shadow-primary/10 scale-[1.02] z-10' 
           : 'border-border/50 hover:border-primary/30 hover:shadow-xl'
@@ -42,16 +42,16 @@ function PricingCard({ plan, index }: { plan: PricingPlan; index: number }) {
         </div>
       )}
 
-      <div className="mb-6 flex min-h-14 items-start pt-2">
-        <h3 className="font-serif text-xl font-semibold text-foreground">
+      <div className="mb-5 flex min-h-14 items-start pt-2">
+        <h3 className="font-serif text-lg font-semibold text-foreground md:text-xl">
           {plan.name}
         </h3>
       </div>
 
       {/* Price */}
-      <div className="mb-6">
+      <div className="mb-5">
         <div className="flex items-baseline gap-1">
-          <span className="font-serif text-4xl font-semibold text-foreground">
+          <span className="font-serif text-3xl font-semibold text-foreground md:text-4xl">
             {formatPrice(plan.price)}
           </span>
         </div>
@@ -63,7 +63,7 @@ function PricingCard({ plan, index }: { plan: PricingPlan; index: number }) {
       </div>
 
       {/* Features */}
-      <ul className="mb-8 flex-1 space-y-3">
+      <ul className="mb-6 flex-1 space-y-3">
         {plan.features.map((feature, featureIndex) => (
           <li key={featureIndex} className="flex items-start gap-3 text-sm text-muted-foreground">
             <div className="mt-0.5 h-5 w-5 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0">
@@ -131,7 +131,7 @@ export function PricingSection() {
       </div>
 
       {/* Pricing cards */}
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="mobile-snap-row lg:grid lg:grid-cols-4">
         {currentPricing.map((plan, index) => (
           <PricingCard key={plan.id} plan={plan} index={index} />
         ))}

--- a/components/sections/programs-section.tsx
+++ b/components/sections/programs-section.tsx
@@ -37,18 +37,18 @@ export function ProgramsSection() {
         subtitle="Выберите формат, который подходит именно вам"
       />
 
-      <div ref={sectionRef} className="grid gap-8 md:grid-cols-2">
+      <div ref={sectionRef} className="mobile-snap-row md:grid md:grid-cols-2">
         {programs.map((program, index) => (
           <div
             key={program.id}
             className={cn(
-              'group overflow-hidden rounded-2xl border border-border/50 bg-card transition-all duration-500 hover:border-primary/30 hover:shadow-2xl hover:-translate-y-1',
+              'mobile-snap-card group overflow-hidden rounded-[1.75rem] border border-border/50 bg-card transition-all duration-500 hover:-translate-y-1 hover:border-primary/30 hover:shadow-2xl',
               isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-12'
             )}
             style={{ transitionDelay: isVisible ? `${index * 150}ms` : '0ms' }}
           >
             {/* Image */}
-            <div className="relative h-56 overflow-hidden">
+            <div className="relative h-48 overflow-hidden md:h-56">
               <ImagePlaceholder
                 src={program.imageUrl}
                 alt={program.title}
@@ -66,13 +66,13 @@ export function ProgramsSection() {
             </div>
 
             {/* Content */}
-            <div className="p-6 md:p-8">
-              <h3 className="font-serif text-2xl font-semibold text-foreground">
+            <div className="p-5 md:p-8">
+              <h3 className="font-serif text-xl font-semibold text-foreground md:text-2xl">
                 {program.title}
               </h3>
 
               {/* Meta */}
-              <div className="mt-4 flex flex-wrap gap-4 text-sm text-muted-foreground">
+              <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground md:mt-4 md:gap-4 md:text-sm">
                 <span className="flex items-center gap-2 bg-muted/50 rounded-full px-3 py-1">
                   <Clock className="h-4 w-4 text-primary" />
                   {program.duration}
@@ -83,12 +83,12 @@ export function ProgramsSection() {
                 </span>
               </div>
 
-              <p className="mt-4 text-muted-foreground leading-relaxed">
+              <p className="mt-4 text-sm leading-relaxed text-muted-foreground md:text-base">
                 {program.description}
               </p>
 
               {/* Features */}
-              <ul className="mt-6 space-y-2">
+              <ul className="mt-5 space-y-2">
                 {program.features.slice(0, 3).map((feature, featureIndex) => (
                   <li key={featureIndex} className="flex items-start gap-3 text-sm text-muted-foreground">
                     <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
@@ -97,7 +97,7 @@ export function ProgramsSection() {
                 ))}
               </ul>
 
-              <div className="mt-8">
+              <div className="mt-6 md:mt-8">
                 <CTAButton variant="outline" size="default" className="w-full justify-center whitespace-nowrap">
                   Записаться
                 </CTAButton>

--- a/components/sections/schedule-section.tsx
+++ b/components/sections/schedule-section.tsx
@@ -65,7 +65,7 @@ export function ScheduleSection() {
       />
 
       {/* Day selector */}
-      <div className="mb-8 flex flex-wrap justify-center gap-2">
+      <div className="mobile-snap-row mb-8 justify-start sm:flex sm:flex-wrap sm:justify-center">
         {weekDays.slice(0, 6).map((day) => {
           const hasSlots = schedule.some((slot) => slot.day === day.full)
           
@@ -75,7 +75,7 @@ export function ScheduleSection() {
               onClick={() => setSelectedDay(day.full)}
               disabled={!hasSlots}
               className={cn(
-                'rounded-lg px-4 py-2 text-sm font-medium transition-all',
+                'mobile-snap-card w-auto rounded-full px-4 py-2 text-sm font-medium transition-all sm:w-auto sm:max-w-none sm:shrink-0',
                 selectedDay === day.full
                   ? 'bg-primary text-primary-foreground'
                   : hasSlots
@@ -108,7 +108,7 @@ export function ScheduleSection() {
       </div>
 
       {/* Legend */}
-      <div className="mt-8 flex flex-wrap justify-center gap-6 text-sm text-muted-foreground">
+      <div className="mt-8 flex flex-col items-center gap-3 text-sm text-muted-foreground sm:flex-row sm:flex-wrap sm:justify-center sm:gap-6">
         <div className="flex items-center gap-2">
           <span className="h-3 w-3 rounded-full bg-primary/20" />
           Групповое занятие

--- a/components/sections/studio-section.tsx
+++ b/components/sections/studio-section.tsx
@@ -42,7 +42,7 @@ export function StudioSection() {
 
         {/* Info */}
         <div className="flex flex-col justify-center">
-          <p className="text-lg text-muted-foreground leading-relaxed whitespace-pre-line">
+          <p className="text-base leading-relaxed text-muted-foreground whitespace-pre-line md:text-lg">
             {studioInfo.description}
           </p>
 
@@ -59,7 +59,7 @@ export function StudioSection() {
           </div>
 
           {/* Working hours */}
-          <div className="mt-8 rounded-lg bg-card p-6 shadow-sm">
+          <div className="mt-8 rounded-2xl bg-card p-5 shadow-sm md:p-6">
             <h3 className="font-medium text-foreground mb-4">Часы работы</h3>
             <ul className="space-y-2">
               {studioInfo.workingHours.map((item) => (

--- a/components/sections/testimonials-section.tsx
+++ b/components/sections/testimonials-section.tsx
@@ -55,23 +55,23 @@ export function TestimonialsSection() {
             isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
           )}
         >
-          <div className="relative rounded-3xl bg-card border border-border/50 p-8 md:p-12 shadow-xl">
+          <div className="relative rounded-3xl border border-border/50 bg-card p-5 shadow-xl md:p-12">
             {/* Quote icon */}
-            <div className="absolute left-8 top-8 md:left-12 md:top-12">
-              <div className="h-16 w-16 rounded-full bg-primary/10 flex items-center justify-center">
-                <Quote className="h-8 w-8 text-primary" />
+            <div className="absolute left-5 top-5 md:left-12 md:top-12">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 md:h-16 md:w-16">
+                <Quote className="h-6 w-6 text-primary md:h-8 md:w-8" />
               </div>
             </div>
 
             {/* Content */}
-            <div className="relative pt-16 md:pt-12">
+            <div className="relative pt-12 md:pt-12">
               {/* Stars */}
               <div className="mb-6 flex justify-center gap-1">
                 {[...Array(5)].map((_, i) => (
                   <Star
                     key={i}
                     className={cn(
-                      'h-6 w-6 transition-all duration-300',
+                      'h-5 w-5 transition-all duration-300 md:h-6 md:w-6',
                       i < currentTestimonial.rating
                         ? 'fill-primary text-primary'
                         : 'text-muted-foreground/30'
@@ -82,7 +82,7 @@ export function TestimonialsSection() {
 
               {/* Text */}
               <blockquote className="text-center">
-                <p className="font-serif text-xl text-foreground md:text-2xl leading-relaxed">
+                <p className="font-serif text-lg leading-relaxed text-foreground md:text-2xl">
                   "{currentTestimonial.text}"
                 </p>
               </blockquote>
@@ -112,12 +112,12 @@ export function TestimonialsSection() {
             </div>
 
             {/* Navigation */}
-            <div className="mt-10 flex items-center justify-center gap-6">
+            <div className="mt-8 flex items-center justify-center gap-3 md:mt-10 md:gap-6">
               <Button
                 variant="outline"
                 size="icon"
                 onClick={prevTestimonial}
-                className="h-12 w-12 rounded-full border-border/50 hover:bg-primary hover:text-primary-foreground hover:border-primary transition-all duration-300"
+                className="h-10 w-10 rounded-full border-border/50 transition-all duration-300 hover:border-primary hover:bg-primary hover:text-primary-foreground md:h-12 md:w-12"
               >
                 <ChevronLeft className="h-5 w-5" />
                 <span className="sr-only">Предыдущий отзыв</span>
@@ -145,7 +145,7 @@ export function TestimonialsSection() {
                 variant="outline"
                 size="icon"
                 onClick={nextTestimonial}
-                className="h-12 w-12 rounded-full border-border/50 hover:bg-primary hover:text-primary-foreground hover:border-primary transition-all duration-300"
+                className="h-10 w-10 rounded-full border-border/50 transition-all duration-300 hover:border-primary hover:bg-primary hover:text-primary-foreground md:h-12 md:w-12"
               >
                 <ChevronRight className="h-5 w-5" />
                 <span className="sr-only">Следующий отзыв</span>
@@ -155,13 +155,13 @@ export function TestimonialsSection() {
         </div>
 
         {/* All testimonials grid (smaller) */}
-        <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mobile-snap-row mt-10 lg:grid lg:grid-cols-3">
           {testimonials.slice(0, 3).map((testimonial, index) => (
             <button
               key={testimonial.id}
               onClick={() => setCurrentIndex(index)}
               className={cn(
-                'text-left rounded-2xl border p-6 transition-all duration-300',
+                'mobile-snap-card text-left rounded-2xl border p-5 transition-all duration-300 md:p-6',
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8',
                 index === currentIndex
                   ? 'border-primary bg-primary/5 shadow-lg'

--- a/components/shared/section-heading.tsx
+++ b/components/shared/section-heading.tsx
@@ -16,16 +16,16 @@ export function SectionHeading({
   return (
     <div
       className={cn(
-        'mb-12 md:mb-16',
+        'mb-8 md:mb-16',
         align === 'center' && 'text-center',
         className
       )}
     >
-      <h2 className="font-serif text-3xl font-semibold tracking-tight text-foreground md:text-4xl lg:text-5xl text-balance">
+      <h2 className="font-serif text-[2rem] font-semibold tracking-tight text-foreground md:text-4xl lg:text-5xl text-balance">
         {title}
       </h2>
       {subtitle && (
-        <p className="mt-4 max-w-2xl text-lg text-muted-foreground md:text-xl leading-relaxed mx-auto text-pretty">
+        <p className="mx-auto mt-3 max-w-2xl text-base leading-relaxed text-muted-foreground md:mt-4 md:text-xl text-pretty">
           {subtitle}
         </p>
       )}


### PR DESCRIPTION
### Motivation
- Improve the mobile UX by making the hero image visible on phones, reducing vertical density and long scrolling caused by stacked cards, and increasing tap-target friendliness. 
- Convert long grid/card sections to mobile-friendly horizontal snap rows while preserving desktop grids to deliver a faster, thumb-first browse experience. 
- Tighten typography and section paddings so content reads better on small screens and CTAs/stats fit the first viewport.

### Description
- Implemented a mobile-first HERO: the background hero image is hidden on small screens and shown inside a compact glass card at the top of the content, CTA layout and stats were made more compact and stack-friendly (changes in `components/sections/hero-section.tsx`).
- Added horizontal snapping utilities `mobile-snap-row` and `mobile-snap-card` to `app/globals.css` and applied them to long card areas so they become swipeable on phones and grid-based on desktop (applied in programs, benefits, method, pricing, testimonials, schedule selectors).
- Reduced global section vertical rhythm by lowering default paddings and tightening section heading sizes for mobile (updates in `components/layout/section-wrapper.tsx` and `components/shared/section-heading.tsx`).
- Adjusted many sections for mobile density and tap targets: `about`, `studio`, `programs`, `pricing`, `benefits`, `method`, `testimonials`, `schedule`, `contact`, and `faq` — including image heights, padding, font sizes, button sizing, and card radii.

### Testing
- `npm run build` — production build completed successfully (Next.js static pages generated). 
- `npm run lint` — failed due to repository missing an `eslint.config.*` file required by ESLint v9; this error is unrelated to the code changes themselves and prevents lint from running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bfeae18208832593ac819da6741fb1)