### PR TITLE
Redesign mobile hero banner

### DIFF
--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -42,13 +42,6 @@ export function HeroSection() {
         <div ref={contentRef} className="w-full max-w-2xl md:py-20">
           <div className="md:hidden">
             <div className="px-1">
-              <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-2">
-                <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
-                <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-primary">
-                  Pilatta Studio
-                </span>
-              </div>
-
               <h1 className="text-balance font-serif text-[2.35rem] font-semibold leading-[0.98] tracking-tight text-foreground">
                 Откройте силу{' '}
                 <span className="text-primary">осознанного</span>{' '}
@@ -75,7 +68,7 @@ export function HeroSection() {
                   <div className="inline-flex items-center gap-2 rounded-full bg-background/85 px-3 py-1.5 backdrop-blur-md">
                     <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
                     <span className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">
-                      Pilatta Studio
+                      Персональные тренировки
                     </span>
                   </div>
                 </div>

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -45,7 +45,7 @@ export function HeroSection() {
               <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-2">
                 <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
                 <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-primary">
-                  Персональные тренировки
+                  Pilatta Studio
                 </span>
               </div>
 
@@ -60,61 +60,60 @@ export function HeroSection() {
               </p>
             </div>
 
-            <div className="relative mt-6 overflow-hidden rounded-[2rem] border border-border/60 bg-card shadow-2xl shadow-primary/10">
-              <ImagePlaceholder
-                src="/images/hero.jpg"
-                alt="Pilatta студия пилатеса"
-                aspectRatio="portrait"
-                className="h-full w-full object-cover"
-                priority
-              />
-              <div className="absolute inset-0 bg-gradient-to-b from-background via-transparent to-transparent" />
-              <div className="absolute inset-0 bg-gradient-to-t from-background/95 via-background/10 to-transparent" />
-              <div className="absolute inset-x-0 bottom-0 p-5">
-                <div className="inline-flex items-center gap-2 rounded-full bg-background/85 px-3 py-1.5 backdrop-blur-md">
-                  <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
-                  <span className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">
-                    Pilatta studio
-                  </span>
+            <div className="mt-6 overflow-hidden rounded-[2rem] border border-border/70 bg-card shadow-2xl shadow-primary/10">
+              <div className="relative">
+                <ImagePlaceholder
+                  src="/images/hero.jpg"
+                  alt="Pilatta студия пилатеса"
+                  aspectRatio="portrait"
+                  className="h-full w-full object-cover"
+                  priority
+                />
+                <div className="absolute inset-0 bg-gradient-to-b from-background via-transparent to-transparent" />
+                <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-card via-card/70 to-transparent" />
+                <div className="absolute inset-x-0 bottom-0 p-5">
+                  <div className="inline-flex items-center gap-2 rounded-full bg-background/85 px-3 py-1.5 backdrop-blur-md">
+                    <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
+                    <span className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">
+                      Pilatta Studio
+                    </span>
+                  </div>
                 </div>
-                <p className="mt-3 max-w-[17rem] text-sm font-medium leading-relaxed text-foreground">
-                  Мягкий вход в практику, внимание к осанке и движение в вашем комфортном темпе.
+              </div>
+
+              <div className="bg-card px-5 pb-5 pt-3">
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  15 лет опыта, персональный подход и программа, адаптированная под тело, цели и текущее самочувствие.
                 </p>
-              </div>
-            </div>
 
-            <div className="-mt-8 relative z-10 rounded-[2rem] border border-border/70 bg-card/95 p-5 shadow-2xl shadow-primary/10 backdrop-blur-md">
-              <p className="text-sm leading-relaxed text-muted-foreground">
-                15 лет опыта, персональный подход и программа, адаптированная под тело, цели и текущее самочувствие.
-              </p>
-
-              <div className="mt-6 flex flex-col gap-3">
-                <CTAButton size="lg" className="w-full shrink-0 shadow-lg shadow-primary/25" />
-                <a
-                  href="#about"
-                  className="group inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-border/60 px-4 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })
-                  }}
-                >
-                  <span>Узнать больше</span>
-                  <ArrowDown className="h-4 w-4 transition-transform group-hover:translate-y-0.5" />
-                </a>
-              </div>
-
-              <div className="mt-6 grid grid-cols-3 gap-3 border-t border-border/50 pt-5">
-                <div>
-                  <div className="font-serif text-xl font-semibold text-foreground">15+</div>
-                  <div className="mt-1 text-xs leading-snug text-muted-foreground">лет опыта</div>
+                <div className="mt-6 grid grid-cols-3 gap-3 border-t border-border/50 pt-5">
+                  <div>
+                    <div className="font-serif text-xl font-semibold text-foreground">15+</div>
+                    <div className="mt-1 text-xs leading-snug text-muted-foreground">лет опыта</div>
+                  </div>
+                  <div>
+                    <div className="font-serif text-xl font-semibold text-foreground">1000+</div>
+                    <div className="mt-1 text-xs leading-snug text-muted-foreground">учеников</div>
+                  </div>
+                  <div>
+                    <div className="font-serif text-xl font-semibold text-foreground">10+</div>
+                    <div className="mt-1 text-xs leading-snug text-muted-foreground">программ</div>
+                  </div>
                 </div>
-                <div>
-                  <div className="font-serif text-xl font-semibold text-foreground">1000+</div>
-                  <div className="mt-1 text-xs leading-snug text-muted-foreground">учеников</div>
-                </div>
-                <div>
-                  <div className="font-serif text-xl font-semibold text-foreground">10+</div>
-                  <div className="mt-1 text-xs leading-snug text-muted-foreground">программ</div>
+
+                <div className="mt-6 flex flex-col gap-3">
+                  <CTAButton size="lg" className="w-full shrink-0 shadow-lg shadow-primary/25" />
+                  <a
+                    href="#about"
+                    className="group inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-border/60 px-4 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })
+                    }}
+                  >
+                    <span>Узнать больше</span>
+                    <ArrowDown className="h-4 w-4 transition-transform group-hover:translate-y-0.5" />
+                  </a>
                 </div>
               </div>
             </div>

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -38,7 +38,7 @@ export function HeroSection() {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 mx-auto flex max-w-7xl items-center px-4 pt-24 pb-12 sm:px-6 sm:pt-28 md:min-h-screen md:px-8 md:py-16">
+      <div className="relative z-10 mx-auto flex max-w-7xl items-center px-4 pt-24 pb-12 sm:px-6 sm:pt-28 md:min-h-screen md:max-w-[88rem] md:px-8 md:py-16 xl:max-w-[96rem]">
         <div ref={contentRef} className="w-full max-w-2xl md:py-20">
           <div className="md:hidden">
             <div className="px-1">

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -40,8 +40,27 @@ export function HeroSection() {
       {/* Content */}
       <div className="relative z-10 mx-auto flex max-w-7xl items-center px-4 pt-6 pb-12 sm:px-6 md:min-h-screen md:px-8 md:py-16">
         <div ref={contentRef} className="w-full max-w-2xl md:py-20">
-          <div className="mb-5 md:hidden">
-            <div className="relative overflow-hidden rounded-[2rem] border border-border/60 bg-card shadow-2xl shadow-primary/10">
+          <div className="md:hidden">
+            <div className="px-1">
+              <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-2">
+                <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
+                <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-primary">
+                  Персональные тренировки
+                </span>
+              </div>
+
+              <h1 className="text-balance font-serif text-[2.35rem] font-semibold leading-[0.98] tracking-tight text-foreground">
+                Откройте силу{' '}
+                <span className="text-primary">осознанного</span>{' '}
+                движения
+              </h1>
+
+              <p className="mt-4 max-w-md text-base leading-relaxed text-muted-foreground text-pretty">
+                Пилатес с сертифицированным тренером для здоровья спины, красивой осанки и гармонии тела.
+              </p>
+            </div>
+
+            <div className="relative mt-6 overflow-hidden rounded-[2rem] border border-border/60 bg-card shadow-2xl shadow-primary/10">
               <ImagePlaceholder
                 src="/images/hero.jpg"
                 alt="Pilatta студия пилатеса"
@@ -49,7 +68,8 @@ export function HeroSection() {
                 className="h-full w-full object-cover"
                 priority
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-background/85 via-background/10 to-transparent" />
+              <div className="absolute inset-0 bg-gradient-to-b from-background via-transparent to-transparent" />
+              <div className="absolute inset-0 bg-gradient-to-t from-background/95 via-background/10 to-transparent" />
               <div className="absolute inset-x-0 bottom-0 p-5">
                 <div className="inline-flex items-center gap-2 rounded-full bg-background/85 px-3 py-1.5 backdrop-blur-md">
                   <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
@@ -57,42 +77,73 @@ export function HeroSection() {
                     Pilatta studio
                   </span>
                 </div>
-                <p className="mt-3 max-w-[16rem] text-sm font-medium leading-relaxed text-foreground">
-                  Спокойный ритм, персональное сопровождение и фокус на результате без перегруза.
+                <p className="mt-3 max-w-[17rem] text-sm font-medium leading-relaxed text-foreground">
+                  Мягкий вход в практику, внимание к осанке и движение в вашем комфортном темпе.
                 </p>
+              </div>
+            </div>
+
+            <div className="-mt-8 relative z-10 rounded-[2rem] border border-border/70 bg-card/95 p-5 shadow-2xl shadow-primary/10 backdrop-blur-md">
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                15 лет опыта, персональный подход и программа, адаптированная под тело, цели и текущее самочувствие.
+              </p>
+
+              <div className="mt-6 flex flex-col gap-3">
+                <CTAButton size="lg" className="w-full shrink-0 shadow-lg shadow-primary/25" />
+                <a
+                  href="#about"
+                  className="group inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-border/60 px-4 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })
+                  }}
+                >
+                  <span>Узнать больше</span>
+                  <ArrowDown className="h-4 w-4 transition-transform group-hover:translate-y-0.5" />
+                </a>
+              </div>
+
+              <div className="mt-6 grid grid-cols-3 gap-3 border-t border-border/50 pt-5">
+                <div>
+                  <div className="font-serif text-xl font-semibold text-foreground">15+</div>
+                  <div className="mt-1 text-xs leading-snug text-muted-foreground">лет опыта</div>
+                </div>
+                <div>
+                  <div className="font-serif text-xl font-semibold text-foreground">1000+</div>
+                  <div className="mt-1 text-xs leading-snug text-muted-foreground">учеников</div>
+                </div>
+                <div>
+                  <div className="font-serif text-xl font-semibold text-foreground">10+</div>
+                  <div className="mt-1 text-xs leading-snug text-muted-foreground">программ</div>
+                </div>
               </div>
             </div>
           </div>
 
-          {/* Text card */}
-          <div className="rounded-[2rem] border border-border/50 bg-card/95 p-5 shadow-2xl shadow-primary/10 backdrop-blur-md sm:p-8 md:rounded-2xl md:bg-card/80 md:p-12">
-            {/* Tagline */}
-            <div className="mb-5 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-2 sm:px-4">
+          {/* Desktop text card */}
+          <div className="hidden rounded-2xl border border-border/50 bg-card/80 p-8 shadow-2xl backdrop-blur-md sm:p-10 md:block md:p-12">
+            <div className="mb-5 inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2">
               <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
-              <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-primary sm:text-sm sm:tracking-wider">
+              <span className="text-sm font-semibold uppercase tracking-wider text-primary">
                 Персональные тренировки
               </span>
             </div>
 
-            {/* Main Heading */}
-            <h1 className="text-balance font-serif text-[2rem] font-semibold leading-[1.05] tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl">
+            <h1 className="text-balance font-serif text-4xl font-semibold leading-tight tracking-tight text-foreground md:text-5xl lg:text-6xl">
               Откройте силу{' '}
               <span className="text-primary">осознанного</span>{' '}
               движения
             </h1>
 
-            {/* Subtitle */}
-            <p className="mt-4 max-w-xl text-base leading-relaxed text-muted-foreground text-pretty sm:mt-6 sm:text-lg md:text-xl">
-              Пилатес с сертифицированным тренером для здоровья спины, 
-              красивой осанки и гармонии тела. 15 лет опыта, индивидуальный подход.
+            <p className="mt-6 max-w-xl text-lg leading-relaxed text-muted-foreground text-pretty md:text-xl">
+              Пилатес с сертифицированным тренером для здоровья спины, красивой осанки и гармонии тела. 15 лет опыта, индивидуальный подход.
             </p>
 
-            {/* CTA */}
-            <div className="mt-6 flex flex-col gap-3 sm:mt-8 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
-              <CTAButton size="lg" className="w-full shrink-0 shadow-lg shadow-primary/25 sm:w-auto" />
+            <div className="mt-8 flex items-center gap-4 flex-wrap">
+              <CTAButton size="lg" className="shadow-lg shadow-primary/25 shrink-0" />
               <a
                 href="#about"
-                className="group inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-border/60 px-4 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground shrink-0 sm:min-h-0 sm:justify-start sm:border-0 sm:px-0"
+                className="group inline-flex items-center gap-2 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground shrink-0"
                 onClick={(e) => {
                   e.preventDefault()
                   document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })
@@ -103,19 +154,18 @@ export function HeroSection() {
               </a>
             </div>
 
-            {/* Stats */}
-            <div className="mt-8 grid grid-cols-3 gap-3 border-t border-border/50 pt-6 sm:mt-10 sm:gap-6 sm:pt-8">
+            <div className="mt-10 grid grid-cols-3 gap-6 border-t border-border/50 pt-8">
               <div>
-                <div className="font-serif text-xl font-semibold text-foreground sm:text-2xl md:text-3xl">15+</div>
-                <div className="mt-1 text-xs leading-snug text-muted-foreground sm:text-sm">лет опыта</div>
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">15+</div>
+                <div className="mt-1 text-sm text-muted-foreground">лет опыта</div>
               </div>
               <div>
-                <div className="font-serif text-xl font-semibold text-foreground sm:text-2xl md:text-3xl">1000+</div>
-                <div className="mt-1 text-xs leading-snug text-muted-foreground sm:text-sm">учеников</div>
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">1000+</div>
+                <div className="mt-1 text-sm text-muted-foreground">учеников</div>
               </div>
               <div>
-                <div className="font-serif text-xl font-semibold text-foreground sm:text-2xl md:text-3xl">10+</div>
-                <div className="mt-1 text-xs leading-snug text-muted-foreground sm:text-sm">программ</div>
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">10+</div>
+                <div className="mt-1 text-sm text-muted-foreground">программ</div>
               </div>
             </div>
           </div>

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -23,9 +23,9 @@ export function HeroSection() {
   }, [])
 
   return (
-    <section id="hero" className="relative min-h-screen overflow-hidden">
-      {/* Background Image with overlay */}
-      <div className="absolute inset-0 z-0">
+    <section id="hero" className="relative overflow-hidden bg-background">
+      {/* Desktop background image with overlay */}
+      <div className="absolute inset-0 z-0 hidden md:block">
         <ImagePlaceholder
           src="/images/hero.jpg"
           alt="Pilatta студия пилатеса"
@@ -38,37 +38,61 @@ export function HeroSection() {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl items-center px-4 sm:px-6 lg:px-8">
-        <div ref={contentRef} className="w-full max-w-2xl py-32">
-          {/* Glass card for text */}
-          <div className="rounded-2xl bg-card/80 backdrop-blur-md border border-border/50 p-8 md:p-12 shadow-2xl">
+      <div className="relative z-10 mx-auto flex max-w-7xl items-center px-4 pt-6 pb-12 sm:px-6 md:min-h-screen md:px-8 md:py-16">
+        <div ref={contentRef} className="w-full max-w-2xl md:py-20">
+          <div className="mb-5 md:hidden">
+            <div className="relative overflow-hidden rounded-[2rem] border border-border/60 bg-card shadow-2xl shadow-primary/10">
+              <ImagePlaceholder
+                src="/images/hero.jpg"
+                alt="Pilatta студия пилатеса"
+                aspectRatio="portrait"
+                className="h-full w-full object-cover"
+                priority
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-background/85 via-background/10 to-transparent" />
+              <div className="absolute inset-x-0 bottom-0 p-5">
+                <div className="inline-flex items-center gap-2 rounded-full bg-background/85 px-3 py-1.5 backdrop-blur-md">
+                  <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
+                  <span className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">
+                    Pilatta studio
+                  </span>
+                </div>
+                <p className="mt-3 max-w-[16rem] text-sm font-medium leading-relaxed text-foreground">
+                  Спокойный ритм, персональное сопровождение и фокус на результате без перегруза.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Text card */}
+          <div className="rounded-[2rem] border border-border/50 bg-card/95 p-5 shadow-2xl shadow-primary/10 backdrop-blur-md sm:p-8 md:rounded-2xl md:bg-card/80 md:p-12">
             {/* Tagline */}
-            <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 mb-6">
+            <div className="mb-5 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-2 sm:px-4">
               <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
-              <span className="text-sm font-semibold uppercase tracking-wider text-primary">
+              <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-primary sm:text-sm sm:tracking-wider">
                 Персональные тренировки
               </span>
             </div>
 
             {/* Main Heading */}
-            <h1 className="font-serif text-4xl font-semibold leading-tight tracking-tight text-foreground md:text-5xl lg:text-6xl text-balance">
+            <h1 className="text-balance font-serif text-[2rem] font-semibold leading-[1.05] tracking-tight text-foreground sm:text-4xl md:text-5xl lg:text-6xl">
               Откройте силу{' '}
               <span className="text-primary">осознанного</span>{' '}
               движения
             </h1>
 
             {/* Subtitle */}
-            <p className="mt-6 text-lg text-muted-foreground md:text-xl leading-relaxed text-pretty">
+            <p className="mt-4 max-w-xl text-base leading-relaxed text-muted-foreground text-pretty sm:mt-6 sm:text-lg md:text-xl">
               Пилатес с сертифицированным тренером для здоровья спины, 
               красивой осанки и гармонии тела. 15 лет опыта, индивидуальный подход.
             </p>
 
             {/* CTA */}
-            <div className="mt-8 flex items-center gap-4 flex-wrap">
-              <CTAButton size="lg" className="shadow-lg shadow-primary/25 shrink-0" />
+            <div className="mt-6 flex flex-col gap-3 sm:mt-8 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
+              <CTAButton size="lg" className="w-full shrink-0 shadow-lg shadow-primary/25 sm:w-auto" />
               <a
                 href="#about"
-                className="group inline-flex items-center gap-2 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground shrink-0"
+                className="group inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-border/60 px-4 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground shrink-0 sm:min-h-0 sm:justify-start sm:border-0 sm:px-0"
                 onClick={(e) => {
                   e.preventDefault()
                   document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })
@@ -80,18 +104,18 @@ export function HeroSection() {
             </div>
 
             {/* Stats */}
-            <div className="mt-10 pt-8 border-t border-border/50 grid grid-cols-3 gap-6">
+            <div className="mt-8 grid grid-cols-3 gap-3 border-t border-border/50 pt-6 sm:mt-10 sm:gap-6 sm:pt-8">
               <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">15+</div>
-                <div className="text-sm text-muted-foreground mt-1">лет опыта</div>
+                <div className="font-serif text-xl font-semibold text-foreground sm:text-2xl md:text-3xl">15+</div>
+                <div className="mt-1 text-xs leading-snug text-muted-foreground sm:text-sm">лет опыта</div>
               </div>
               <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">1000+</div>
-                <div className="text-sm text-muted-foreground mt-1">учеников</div>
+                <div className="font-serif text-xl font-semibold text-foreground sm:text-2xl md:text-3xl">1000+</div>
+                <div className="mt-1 text-xs leading-snug text-muted-foreground sm:text-sm">учеников</div>
               </div>
               <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">10+</div>
-                <div className="text-sm text-muted-foreground mt-1">программ</div>
+                <div className="font-serif text-xl font-semibold text-foreground sm:text-2xl md:text-3xl">10+</div>
+                <div className="mt-1 text-xs leading-snug text-muted-foreground sm:text-sm">программ</div>
               </div>
             </div>
           </div>

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -38,7 +38,7 @@ export function HeroSection() {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 mx-auto flex max-w-7xl items-center px-4 pt-6 pb-12 sm:px-6 md:min-h-screen md:px-8 md:py-16">
+      <div className="relative z-10 mx-auto flex max-w-7xl items-center px-4 pt-24 pb-12 sm:px-6 sm:pt-28 md:min-h-screen md:px-8 md:py-16">
         <div ref={contentRef} className="w-full max-w-2xl md:py-20">
           <div className="md:hidden">
             <div className="px-1">


### PR DESCRIPTION
### Motivation
- The current HERO is desktop-first and hides the studio photo and wastes vertical space on phones, so mobile users see a poor first-screen experience. 
- The goal is to surface the hero image on small screens, tighten spacing and typography, and make CTAs and stats touch-friendly to reduce vertical bloat. 
- Desktop behavior (fullscreen background + overlays and entrance animation) should be preserved at `md+` breakpoints.

### Description
- Updated `components/sections/hero-section.tsx` to hide the fullscreen background image on small screens and keep it for `md+` via a responsive wrapper. 
- Added a dedicated mobile visual card (portrait image with badge and short blurb) that is shown only on mobile to ensure the studio photo remains visible. 
- Reworked the text card for mobile by reducing paddings and type sizes, making the H1 and subtitle more adaptive, and preserving the existing entrance animation. 
- Adjusted CTA layout to make the primary button full-width on mobile and compacted the stats block typography and spacing for a denser mobile layout.

### Testing
- Ran `npm run build`, which completed successfully and generated the static pages. 
- Ran `npm run lint`, which failed due to a missing ESLint flat config file (`eslint.config.(js|mjs|cjs)`), so linting could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bff588e4d4832597f81ba78ae7e92e)