### PR TITLE
Improve hero responsiveness, add swipeable principles carousel and UI/UI refinements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -130,4 +130,25 @@
   .text-brand-balance {
     text-wrap: balance;
   }
+
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@keyframes swipe-hint {
+  0%,
+  100% {
+    transform: translateX(0);
+    opacity: 0.45;
+  }
+  50% {
+    transform: translateX(6px);
+    opacity: 1;
+  }
 }

--- a/components/sections/benefits-section.tsx
+++ b/components/sections/benefits-section.tsx
@@ -51,12 +51,12 @@ export function BenefitsSection() {
         subtitle="Метод, который трансформирует тело и улучшает качество жизни"
       />
 
-      <div ref={sectionRef} className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div ref={sectionRef} className="grid grid-cols-2 gap-4 sm:gap-5 lg:grid-cols-3 lg:gap-6">
         {benefits.map((benefit, index) => (
           <div
             key={benefit.id}
             className={cn(
-              'group relative flex flex-col rounded-2xl bg-card p-8 shadow-sm border border-border/50 transition-all duration-500 hover:shadow-xl hover:shadow-primary/5 hover:-translate-y-1',
+              'group relative flex h-full flex-col rounded-[1.5rem] border border-border/50 bg-card p-5 shadow-sm transition-all duration-500 hover:shadow-xl hover:shadow-primary/5 sm:rounded-2xl sm:p-6 lg:p-8 lg:hover:-translate-y-1',
               isVisible
                 ? 'opacity-100 translate-y-0'
                 : 'opacity-0 translate-y-8'
@@ -69,13 +69,13 @@ export function BenefitsSection() {
             <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-primary/5 via-transparent to-accent/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
             
             <div className="relative z-10">
-              <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 text-primary transition-all duration-300 group-hover:scale-110 group-hover:from-primary group-hover:to-primary/80 group-hover:text-primary-foreground">
+              <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 text-primary transition-all duration-300 group-hover:scale-110 group-hover:from-primary group-hover:to-primary/80 group-hover:text-primary-foreground sm:mb-5 sm:h-12 sm:w-12 lg:h-14 lg:w-14">
                 {iconMap[benefit.icon] || <Sparkles className="h-6 w-6" />}
               </div>
-              <h3 className="font-serif text-xl font-semibold text-foreground">
+              <h3 className="font-serif text-lg font-semibold leading-tight text-foreground sm:text-xl">
                 {benefit.title}
               </h3>
-              <p className="mt-3 text-muted-foreground leading-relaxed">
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:mt-3 sm:text-base">
                 {benefit.description}
               </p>
             </div>

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -23,9 +23,9 @@ export function HeroSection() {
   }, [])
 
   return (
-    <section id="hero" className="relative min-h-screen overflow-hidden">
-      {/* Background Image with overlay */}
-      <div className="absolute inset-0 z-0">
+    <section id="hero" className="relative overflow-hidden bg-background">
+      {/* Desktop background image with overlay */}
+      <div className="absolute inset-0 z-0 hidden md:block">
         <ImagePlaceholder
           src="/images/hero.jpg"
           alt="Pilatta студия пилатеса"
@@ -38,32 +38,99 @@ export function HeroSection() {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl items-center px-4 sm:px-6 lg:px-8">
-        <div ref={contentRef} className="w-full max-w-2xl py-32">
-          {/* Glass card for text */}
-          <div className="rounded-2xl bg-card/80 backdrop-blur-md border border-border/50 p-8 md:p-12 shadow-2xl">
-            {/* Tagline */}
-            <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 mb-6">
+      <div className="relative z-10 mx-auto flex max-w-7xl items-center px-4 pt-24 pb-12 sm:px-6 sm:pt-28 md:min-h-screen md:max-w-[88rem] md:px-8 md:py-16 xl:max-w-[96rem]">
+        <div ref={contentRef} className="w-full max-w-2xl md:py-20">
+          <div className="md:hidden">
+            <div className="px-1">
+              <h1 className="text-balance font-serif text-[2.35rem] font-semibold leading-[0.98] tracking-tight text-foreground">
+                Откройте силу{' '}
+                <span className="text-primary">осознанного</span>{' '}
+                движения
+              </h1>
+
+              <p className="mt-4 max-w-md text-base leading-relaxed text-muted-foreground text-pretty">
+                Пилатес с сертифицированным тренером для здоровья спины, красивой осанки и гармонии тела.
+              </p>
+            </div>
+
+            <div className="mt-6 overflow-hidden rounded-[2rem] border border-border/70 bg-card shadow-2xl shadow-primary/10">
+              <div className="relative">
+                <ImagePlaceholder
+                  src="/images/hero.jpg"
+                  alt="Pilatta студия пилатеса"
+                  aspectRatio="portrait"
+                  className="h-full w-full object-cover"
+                  priority
+                />
+                <div className="absolute inset-0 bg-gradient-to-b from-background via-transparent to-transparent" />
+                <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-card via-card/70 to-transparent" />
+                <div className="absolute inset-x-0 bottom-0 p-5">
+                  <div className="inline-flex items-center gap-2 rounded-full bg-background/85 px-3 py-1.5 backdrop-blur-md">
+                    <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
+                    <span className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">
+                      Персональные тренировки
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-card px-5 pb-5 pt-3">
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  15 лет опыта, персональный подход и программа, адаптированная под тело, цели и текущее самочувствие.
+                </p>
+
+                <div className="mt-6 grid grid-cols-3 gap-3 border-t border-border/50 pt-5">
+                  <div>
+                    <div className="font-serif text-xl font-semibold text-foreground">15+</div>
+                    <div className="mt-1 text-xs leading-snug text-muted-foreground">лет опыта</div>
+                  </div>
+                  <div>
+                    <div className="font-serif text-xl font-semibold text-foreground">1000+</div>
+                    <div className="mt-1 text-xs leading-snug text-muted-foreground">учеников</div>
+                  </div>
+                  <div>
+                    <div className="font-serif text-xl font-semibold text-foreground">10+</div>
+                    <div className="mt-1 text-xs leading-snug text-muted-foreground">программ</div>
+                  </div>
+                </div>
+
+                <div className="mt-6 flex flex-col gap-3">
+                  <CTAButton size="lg" className="w-full shrink-0 shadow-lg shadow-primary/25" />
+                  <a
+                    href="#about"
+                    className="group inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-border/60 px-4 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })
+                    }}
+                  >
+                    <span>Узнать больше</span>
+                    <ArrowDown className="h-4 w-4 transition-transform group-hover:translate-y-0.5" />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Desktop text card */}
+          <div className="hidden rounded-2xl border border-border/50 bg-card/80 p-8 shadow-2xl backdrop-blur-md sm:p-10 md:block md:p-12">
+            <div className="mb-5 inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2">
               <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
               <span className="text-sm font-semibold uppercase tracking-wider text-primary">
                 Персональные тренировки
               </span>
             </div>
 
-            {/* Main Heading */}
-            <h1 className="font-serif text-4xl font-semibold leading-tight tracking-tight text-foreground md:text-5xl lg:text-6xl text-balance">
+            <h1 className="text-balance font-serif text-4xl font-semibold leading-tight tracking-tight text-foreground md:text-5xl lg:text-6xl">
               Откройте силу{' '}
               <span className="text-primary">осознанного</span>{' '}
               движения
             </h1>
 
-            {/* Subtitle */}
-            <p className="mt-6 text-lg text-muted-foreground md:text-xl leading-relaxed text-pretty">
-              Пилатес с сертифицированным тренером для здоровья спины, 
-              красивой осанки и гармонии тела. 15 лет опыта, индивидуальный подход.
+            <p className="mt-6 max-w-xl text-lg leading-relaxed text-muted-foreground text-pretty md:text-xl">
+              Пилатес с сертифицированным тренером для здоровья спины, красивой осанки и гармонии тела. 15 лет опыта, индивидуальный подход.
             </p>
 
-            {/* CTA */}
             <div className="mt-8 flex items-center gap-4 flex-wrap">
               <CTAButton size="lg" className="shadow-lg shadow-primary/25 shrink-0" />
               <a
@@ -79,19 +146,18 @@ export function HeroSection() {
               </a>
             </div>
 
-            {/* Stats */}
-            <div className="mt-10 pt-8 border-t border-border/50 grid grid-cols-3 gap-6">
+            <div className="mt-10 grid grid-cols-3 gap-6 border-t border-border/50 pt-8">
               <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">15+</div>
-                <div className="text-sm text-muted-foreground mt-1">лет опыта</div>
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">15+</div>
+                <div className="mt-1 text-sm text-muted-foreground">лет опыта</div>
               </div>
               <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">1000+</div>
-                <div className="text-sm text-muted-foreground mt-1">учеников</div>
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">1000+</div>
+                <div className="mt-1 text-sm text-muted-foreground">учеников</div>
               </div>
               <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">10+</div>
-                <div className="text-sm text-muted-foreground mt-1">программ</div>
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">10+</div>
+                <div className="mt-1 text-sm text-muted-foreground">программ</div>
               </div>
             </div>
           </div>

--- a/components/sections/method-section.tsx
+++ b/components/sections/method-section.tsx
@@ -42,7 +42,10 @@ const principles = [
 
 export function MethodSection() {
   const [isVisible, setIsVisible] = useState(false)
+  const [activePrinciple, setActivePrinciple] = useState(0)
+  const [showSwipeHint, setShowSwipeHint] = useState(true)
   const sectionRef = useRef<HTMLDivElement>(null)
+  const cardsRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -61,6 +64,60 @@ export function MethodSection() {
     return () => observer.disconnect()
   }, [])
 
+  useEffect(() => {
+    const container = cardsRef.current
+    if (!container) return
+
+    const cardElements = Array.from(container.children) as HTMLElement[]
+    if (cardElements.length === 0) return
+
+    const updateActiveCard = () => {
+      const currentScroll = container.scrollLeft
+      let nearestIndex = 0
+      let nearestDistance = Number.POSITIVE_INFINITY
+
+      cardElements.forEach((card, index) => {
+        const distance = Math.abs(card.offsetLeft - currentScroll)
+        if (distance < nearestDistance) {
+          nearestDistance = distance
+          nearestIndex = index
+        }
+      })
+
+      setActivePrinciple(nearestIndex)
+
+      if (currentScroll > 12) {
+        setShowSwipeHint(false)
+      }
+    }
+
+    updateActiveCard()
+    container.addEventListener('scroll', updateActiveCard, { passive: true })
+    window.addEventListener('resize', updateActiveCard)
+
+    const hintTimer = window.setTimeout(() => {
+      setShowSwipeHint(false)
+    }, 5000)
+
+    return () => {
+      container.removeEventListener('scroll', updateActiveCard)
+      window.removeEventListener('resize', updateActiveCard)
+      window.clearTimeout(hintTimer)
+    }
+  }, [])
+
+  const scrollToPrinciple = (index: number) => {
+    const container = cardsRef.current
+    const card = container?.children[index] as HTMLElement | undefined
+
+    if (!container || !card) return
+
+    container.scrollTo({
+      left: card.offsetLeft,
+      behavior: 'smooth',
+    })
+  }
+
   return (
     <SectionWrapper id="method" background="muted" animate={false}>
       <div ref={sectionRef}>
@@ -72,19 +129,19 @@ export function MethodSection() {
         {/* Philosophy quote */}
         <div 
           className={cn(
-            'mx-auto mb-16 max-w-3xl relative transition-all duration-700',
+            'relative mx-auto mb-10 max-w-3xl transition-all duration-700 md:mb-16',
             isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
           )}
         >
-          <div className="absolute -top-6 left-8 text-primary/20">
-            <Quote className="h-16 w-16" />
+          <div className="absolute -top-4 left-5 text-primary/20 md:-top-6 md:left-8">
+            <Quote className="h-12 w-12 md:h-16 md:w-16" />
           </div>
-          <div className="rounded-2xl bg-card border border-border/50 p-8 md:p-12 shadow-lg relative">
+          <div className="relative rounded-2xl border border-border/50 bg-card p-6 shadow-lg md:p-12">
             <blockquote className="text-center">
-              <p className="font-serif text-xl text-foreground md:text-2xl leading-relaxed">
+              <p className="font-serif text-lg leading-relaxed text-foreground md:text-2xl">
                 {trainer.philosophy}
               </p>
-              <footer className="mt-6 flex items-center justify-center gap-3">
+              <footer className="mt-5 flex items-center justify-center gap-3 md:mt-6">
                 <div className="h-px w-12 bg-primary/30" />
                 <span className="text-sm font-semibold text-primary">{trainer.name}</span>
                 <div className="h-px w-12 bg-primary/30" />
@@ -94,33 +151,68 @@ export function MethodSection() {
         </div>
 
         {/* Principles grid */}
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mb-4 flex items-center justify-between gap-3 px-1 sm:hidden">
+          <div>
+            <p className="font-serif text-[1.1rem] font-semibold leading-tight tracking-tight text-foreground">
+              6 ключевых принципов
+            </p>
+          </div>
+          <div className="min-h-5">
+            {showSwipeHint && (
+              <p className="flex items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                <span>листайте</span>
+                <span className="inline-block motion-safe:animate-[swipe-hint_1.8s_ease-in-out_infinite]">→</span>
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div
+          ref={cardsRef}
+          className="flex snap-x snap-mandatory gap-4 overflow-x-auto px-1 pt-2 pb-5 no-scrollbar overscroll-x-contain sm:grid sm:grid-cols-2 sm:gap-6 sm:overflow-visible sm:px-0 sm:pt-0 sm:pb-0 lg:grid-cols-3"
+        >
           {principles.map((principle, index) => (
             <div
               key={principle.number}
               className={cn(
-                'group relative rounded-2xl border border-border/50 bg-card p-8 transition-all duration-500 hover:border-primary/30 hover:shadow-xl hover:-translate-y-1',
+                'group relative basis-full shrink-0 snap-start rounded-[1.75rem] border border-border/50 bg-card p-6 shadow-[0_18px_40px_-32px_rgba(41,25,15,0.32)] transition-all duration-500 hover:border-primary/30 hover:shadow-xl sm:basis-auto sm:rounded-2xl sm:p-7 lg:p-8 lg:hover:-translate-y-1',
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
               )}
               style={{ transitionDelay: isVisible ? `${index * 100}ms` : '0ms' }}
             >
               {/* Number badge */}
-              <div className="absolute -top-3 -left-3 h-10 w-10 rounded-xl bg-primary flex items-center justify-center shadow-lg shadow-primary/25">
+              <div className="absolute left-5 top-5 flex h-10 w-10 items-center justify-center rounded-xl bg-primary shadow-lg shadow-primary/25 sm:-left-3 sm:-top-3 sm:h-10 sm:w-10">
                 <span className="text-sm font-bold text-primary-foreground">
                   {principle.number}
                 </span>
               </div>
               
-              <h3 className="mt-2 font-serif text-xl font-semibold text-foreground">
+              <h3 className="mt-14 font-serif text-[1.7rem] leading-none font-semibold text-foreground sm:mt-2 sm:text-xl">
                 {principle.title}
               </h3>
-              <p className="mt-3 text-muted-foreground leading-relaxed">
+              <p className="mt-4 min-h-[4.5rem] text-base leading-relaxed text-muted-foreground sm:min-h-0 sm:text-base">
                 {principle.description}
               </p>
               
               {/* Hover gradient */}
-              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-primary/5 via-transparent to-accent/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-primary/5 via-transparent to-accent/5 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
             </div>
+          ))}
+        </div>
+
+        <div className="mt-4 flex items-center justify-center gap-2 sm:hidden">
+          {principles.map((principle, index) => (
+            <button
+              key={principle.number}
+              type="button"
+              aria-label={`Перейти к принципу ${principle.number}`}
+              aria-current={activePrinciple === index}
+              onClick={() => scrollToPrinciple(index)}
+              className={cn(
+                'h-1.5 rounded-full bg-primary/20 transition-all duration-300',
+                activePrinciple === index ? 'w-6 bg-primary' : 'w-1.5'
+              )}
+            />
           ))}
         </div>
       </div>

--- a/components/sections/testimonials-section.tsx
+++ b/components/sections/testimonials-section.tsx
@@ -81,7 +81,7 @@ export function TestimonialsSection() {
               </div>
 
               {/* Text */}
-              <blockquote className="text-center">
+              <blockquote className="flex min-h-[15rem] items-center justify-center text-center md:min-h-[11rem] lg:min-h-[9rem]">
                 <p className="font-serif text-xl text-foreground md:text-2xl leading-relaxed">
                   "{currentTestimonial.text}"
                 </p>

--- a/components/sections/testimonials-section.tsx
+++ b/components/sections/testimonials-section.tsx
@@ -11,7 +11,9 @@ import { cn } from '@/lib/utils'
 export function TestimonialsSection() {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isVisible, setIsVisible] = useState(false)
+  const [quoteMinHeight, setQuoteMinHeight] = useState(0)
   const sectionRef = useRef<HTMLDivElement>(null)
+  const measureRefs = useRef<(HTMLParagraphElement | null)[]>([])
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -28,6 +30,26 @@ export function TestimonialsSection() {
     }
 
     return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const measureQuoteHeight = () => {
+      const heights = measureRefs.current
+        .map((element) => element?.getBoundingClientRect().height ?? 0)
+        .filter(Boolean)
+
+      if (heights.length > 0) {
+        setQuoteMinHeight(Math.ceil(Math.max(...heights)))
+      }
+    }
+
+    const animationFrame = window.requestAnimationFrame(measureQuoteHeight)
+    window.addEventListener('resize', measureQuoteHeight)
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame)
+      window.removeEventListener('resize', measureQuoteHeight)
+    }
   }, [])
 
   const nextTestimonial = () => {
@@ -56,6 +78,23 @@ export function TestimonialsSection() {
           )}
         >
           <div className="relative rounded-3xl bg-card border border-border/50 p-8 md:p-12 shadow-xl">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute left-8 right-8 top-24 opacity-0 md:left-12 md:right-12 md:top-24"
+            >
+              {testimonials.map((testimonial, index) => (
+                <p
+                  key={testimonial.id}
+                  ref={(element) => {
+                    measureRefs.current[index] = element
+                  }}
+                  className="font-serif text-xl leading-relaxed text-foreground md:text-2xl"
+                >
+                  "{testimonial.text}"
+                </p>
+              ))}
+            </div>
+
             {/* Quote icon */}
             <div className="absolute left-8 top-8 md:left-12 md:top-12">
               <div className="h-16 w-16 rounded-full bg-primary/10 flex items-center justify-center">
@@ -81,7 +120,10 @@ export function TestimonialsSection() {
               </div>
 
               {/* Text */}
-              <blockquote className="flex min-h-[15rem] items-center justify-center text-center md:min-h-[11rem] lg:min-h-[9rem]">
+              <blockquote
+                className="flex items-center justify-center text-center"
+                style={quoteMinHeight > 0 ? { minHeight: `${quoteMinHeight}px` } : undefined}
+              >
                 <p className="font-serif text-xl text-foreground md:text-2xl leading-relaxed">
                   "{currentTestimonial.text}"
                 </p>


### PR DESCRIPTION
### Motivation
- Improve mobile and desktop presentation of the hero and method sections for better readability and conversion. 
- Make the principles list more usable on small screens by enabling horizontal swipe navigation and visual indicators. 
- Harmonize spacing, typography and interactive states across benefits, testimonials and global utilities for a cleaner UI.

### Description
- Added global utilities in `app/globals.css` including `.no-scrollbar` and `@keyframes swipe-hint` to support the new swipe UI and hide native scrollbars. 
- Reworked `HeroSection` to provide a mobile-first card layout, separate desktop background handling, entrance animation, adjusted spacing and CTA placement, and responsive stats presentation. 
- Updated `BenefitsSection` with refined grid/gap sizes, responsive icon and text sizing, updated card spacing and hover styles, and adjusted transition timings. 
- Implemented a swipeable, snap-enabled carousel for principles in `MethodSection` with state tracking (`activePrinciple`, `showSwipeHint`), scroll listener, `scrollToPrinciple` navigation, swipe hint and responsive layout fallbacks to the grid on larger screens. 
- Touched `TestimonialsSection` blockquote layout to enforce consistent min-height for smoother visual rhythm. 

### Testing
- Ran a production build with `npm run build` and the build completed successfully. 
- Executed linting with `npm run lint` and there were no lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bff588e4d4832597f81ba78ae7e92e)