### PR TITLE
Improve responsive hero/method/testimonials, add theme view-transition and CSS utilities

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -121,7 +121,7 @@
     @apply overflow-x-clip;
   }
   body {
-    @apply bg-background text-foreground overflow-x-clip;
+    @apply bg-background text-foreground overflow-x-clip transition-colors duration-300;
     font-feature-settings: 'liga' 1, 'kern' 1;
   }
 }
@@ -129,5 +129,65 @@
 @layer utilities {
   .text-brand-balance {
     text-wrap: balance;
+  }
+
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@keyframes swipe-hint {
+  0%,
+  100% {
+    transform: translateX(0);
+    opacity: 0.45;
+  }
+  50% {
+    transform: translateX(6px);
+    opacity: 1;
+  }
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 320ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+::view-transition-old(root) {
+  animation-name: theme-fade-out;
+}
+
+::view-transition-new(root) {
+  animation-name: theme-fade-in;
+}
+
+@keyframes theme-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes theme-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 1ms;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,6 @@ export default function RootLayout({
           attribute="class"
           defaultTheme="light"
           enableSystem
-          disableTransitionOnChange
         >
           {children}
         </ThemeProvider>

--- a/components/sections/benefits-section.tsx
+++ b/components/sections/benefits-section.tsx
@@ -51,12 +51,12 @@ export function BenefitsSection() {
         subtitle="Метод, который трансформирует тело и улучшает качество жизни"
       />
 
-      <div ref={sectionRef} className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div ref={sectionRef} className="grid grid-cols-2 gap-4 sm:gap-5 lg:grid-cols-3 lg:gap-6">
         {benefits.map((benefit, index) => (
           <div
             key={benefit.id}
             className={cn(
-              'group relative flex flex-col rounded-2xl bg-card p-8 shadow-sm border border-border/50 transition-all duration-500 hover:shadow-xl hover:shadow-primary/5 hover:-translate-y-1',
+              'group relative flex h-full flex-col rounded-[1.5rem] border border-border/50 bg-card p-5 shadow-sm transition-all duration-500 hover:shadow-xl hover:shadow-primary/5 sm:rounded-2xl sm:p-6 lg:p-8 lg:hover:-translate-y-1',
               isVisible
                 ? 'opacity-100 translate-y-0'
                 : 'opacity-0 translate-y-8'
@@ -69,13 +69,13 @@ export function BenefitsSection() {
             <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-primary/5 via-transparent to-accent/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
             
             <div className="relative z-10">
-              <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 text-primary transition-all duration-300 group-hover:scale-110 group-hover:from-primary group-hover:to-primary/80 group-hover:text-primary-foreground">
+              <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-primary/20 to-primary/5 text-primary transition-all duration-300 group-hover:scale-110 group-hover:from-primary group-hover:to-primary/80 group-hover:text-primary-foreground sm:mb-5 sm:h-12 sm:w-12 lg:h-14 lg:w-14">
                 {iconMap[benefit.icon] || <Sparkles className="h-6 w-6" />}
               </div>
-              <h3 className="font-serif text-xl font-semibold text-foreground">
+              <h3 className="font-serif text-lg font-semibold leading-tight text-foreground sm:text-xl">
                 {benefit.title}
               </h3>
-              <p className="mt-3 text-muted-foreground leading-relaxed">
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:mt-3 sm:text-base">
                 {benefit.description}
               </p>
             </div>

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -23,9 +23,9 @@ export function HeroSection() {
   }, [])
 
   return (
-    <section id="hero" className="relative min-h-screen overflow-hidden">
-      {/* Background Image with overlay */}
-      <div className="absolute inset-0 z-0">
+    <section id="hero" className="relative overflow-hidden bg-background">
+      {/* Desktop background image with overlay */}
+      <div className="absolute inset-0 z-0 hidden md:block">
         <ImagePlaceholder
           src="/images/hero.jpg"
           alt="Pilatta студия пилатеса"
@@ -38,32 +38,99 @@ export function HeroSection() {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl items-center px-4 sm:px-6 lg:px-8">
-        <div ref={contentRef} className="w-full max-w-2xl py-32">
-          {/* Glass card for text */}
-          <div className="rounded-2xl bg-card/80 backdrop-blur-md border border-border/50 p-8 md:p-12 shadow-2xl">
-            {/* Tagline */}
-            <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 mb-6">
+      <div className="relative z-10 mx-auto flex max-w-7xl items-center px-4 pt-24 pb-12 sm:px-6 sm:pt-28 md:min-h-screen md:max-w-[88rem] md:px-8 md:py-16 xl:max-w-[96rem]">
+        <div ref={contentRef} className="w-full max-w-2xl md:py-20">
+          <div className="md:hidden">
+            <div className="px-1">
+              <h1 className="text-balance font-serif text-[2.35rem] font-semibold leading-[0.98] tracking-tight text-foreground">
+                Откройте силу{' '}
+                <span className="text-primary">осознанного</span>{' '}
+                движения
+              </h1>
+
+              <p className="mt-4 max-w-md text-base leading-relaxed text-muted-foreground text-pretty">
+                Пилатес с сертифицированным тренером для здоровья спины, красивой осанки и гармонии тела.
+              </p>
+            </div>
+
+            <div className="mt-6 overflow-hidden rounded-[2rem] border border-border/70 bg-card shadow-2xl shadow-primary/10">
+              <div className="relative">
+                <ImagePlaceholder
+                  src="/images/hero.jpg"
+                  alt="Pilatta студия пилатеса"
+                  aspectRatio="portrait"
+                  className="h-full w-full object-cover"
+                  priority
+                />
+                <div className="absolute inset-0 bg-gradient-to-b from-background via-transparent to-transparent" />
+                <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-card via-card/70 to-transparent" />
+                <div className="absolute inset-x-0 bottom-0 p-5">
+                  <div className="inline-flex items-center gap-2 rounded-full bg-background/85 px-3 py-1.5 backdrop-blur-md">
+                    <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
+                    <span className="text-xs font-semibold uppercase tracking-[0.24em] text-primary">
+                      Персональные тренировки
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-card px-5 pb-5 pt-3">
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  15 лет опыта, персональный подход и программа, адаптированная под тело, цели и текущее самочувствие.
+                </p>
+
+                <div className="mt-6 grid grid-cols-3 gap-3 border-t border-border/50 pt-5">
+                  <div>
+                    <div className="font-serif text-xl font-semibold text-foreground">15+</div>
+                    <div className="mt-1 text-xs leading-snug text-muted-foreground">лет опыта</div>
+                  </div>
+                  <div>
+                    <div className="font-serif text-xl font-semibold text-foreground">1000+</div>
+                    <div className="mt-1 text-xs leading-snug text-muted-foreground">учеников</div>
+                  </div>
+                  <div>
+                    <div className="font-serif text-xl font-semibold text-foreground">10+</div>
+                    <div className="mt-1 text-xs leading-snug text-muted-foreground">программ</div>
+                  </div>
+                </div>
+
+                <div className="mt-6 flex flex-col gap-3">
+                  <CTAButton size="lg" className="w-full shrink-0 shadow-lg shadow-primary/25" />
+                  <a
+                    href="#about"
+                    className="group inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-border/60 px-4 text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      document.getElementById('about')?.scrollIntoView({ behavior: 'smooth' })
+                    }}
+                  >
+                    <span>Узнать больше</span>
+                    <ArrowDown className="h-4 w-4 transition-transform group-hover:translate-y-0.5" />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Desktop text card */}
+          <div className="hidden rounded-2xl border border-border/50 bg-card/80 p-8 shadow-2xl backdrop-blur-md sm:p-10 md:block md:p-12">
+            <div className="mb-5 inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2">
               <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
               <span className="text-sm font-semibold uppercase tracking-wider text-primary">
                 Персональные тренировки
               </span>
             </div>
 
-            {/* Main Heading */}
-            <h1 className="font-serif text-4xl font-semibold leading-tight tracking-tight text-foreground md:text-5xl lg:text-6xl text-balance">
+            <h1 className="text-balance font-serif text-4xl font-semibold leading-tight tracking-tight text-foreground md:text-5xl lg:text-6xl">
               Откройте силу{' '}
               <span className="text-primary">осознанного</span>{' '}
               движения
             </h1>
 
-            {/* Subtitle */}
-            <p className="mt-6 text-lg text-muted-foreground md:text-xl leading-relaxed text-pretty">
-              Пилатес с сертифицированным тренером для здоровья спины, 
-              красивой осанки и гармонии тела. 15 лет опыта, индивидуальный подход.
+            <p className="mt-6 max-w-xl text-lg leading-relaxed text-muted-foreground text-pretty md:text-xl">
+              Пилатес с сертифицированным тренером для здоровья спины, красивой осанки и гармонии тела. 15 лет опыта, индивидуальный подход.
             </p>
 
-            {/* CTA */}
             <div className="mt-8 flex items-center gap-4 flex-wrap">
               <CTAButton size="lg" className="shadow-lg shadow-primary/25 shrink-0" />
               <a
@@ -79,19 +146,18 @@ export function HeroSection() {
               </a>
             </div>
 
-            {/* Stats */}
-            <div className="mt-10 pt-8 border-t border-border/50 grid grid-cols-3 gap-6">
+            <div className="mt-10 grid grid-cols-3 gap-6 border-t border-border/50 pt-8">
               <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">15+</div>
-                <div className="text-sm text-muted-foreground mt-1">лет опыта</div>
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">15+</div>
+                <div className="mt-1 text-sm text-muted-foreground">лет опыта</div>
               </div>
               <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">1000+</div>
-                <div className="text-sm text-muted-foreground mt-1">учеников</div>
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">1000+</div>
+                <div className="mt-1 text-sm text-muted-foreground">учеников</div>
               </div>
               <div>
-                <div className="text-2xl md:text-3xl font-serif font-semibold text-foreground">10+</div>
-                <div className="text-sm text-muted-foreground mt-1">программ</div>
+                <div className="font-serif text-2xl font-semibold text-foreground md:text-3xl">10+</div>
+                <div className="mt-1 text-sm text-muted-foreground">программ</div>
               </div>
             </div>
           </div>

--- a/components/sections/method-section.tsx
+++ b/components/sections/method-section.tsx
@@ -42,7 +42,10 @@ const principles = [
 
 export function MethodSection() {
   const [isVisible, setIsVisible] = useState(false)
+  const [activePrinciple, setActivePrinciple] = useState(0)
+  const [showSwipeHint, setShowSwipeHint] = useState(true)
   const sectionRef = useRef<HTMLDivElement>(null)
+  const cardsRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -61,6 +64,60 @@ export function MethodSection() {
     return () => observer.disconnect()
   }, [])
 
+  useEffect(() => {
+    const container = cardsRef.current
+    if (!container) return
+
+    const cardElements = Array.from(container.children) as HTMLElement[]
+    if (cardElements.length === 0) return
+
+    const updateActiveCard = () => {
+      const currentScroll = container.scrollLeft
+      let nearestIndex = 0
+      let nearestDistance = Number.POSITIVE_INFINITY
+
+      cardElements.forEach((card, index) => {
+        const distance = Math.abs(card.offsetLeft - currentScroll)
+        if (distance < nearestDistance) {
+          nearestDistance = distance
+          nearestIndex = index
+        }
+      })
+
+      setActivePrinciple(nearestIndex)
+
+      if (currentScroll > 12) {
+        setShowSwipeHint(false)
+      }
+    }
+
+    updateActiveCard()
+    container.addEventListener('scroll', updateActiveCard, { passive: true })
+    window.addEventListener('resize', updateActiveCard)
+
+    const hintTimer = window.setTimeout(() => {
+      setShowSwipeHint(false)
+    }, 5000)
+
+    return () => {
+      container.removeEventListener('scroll', updateActiveCard)
+      window.removeEventListener('resize', updateActiveCard)
+      window.clearTimeout(hintTimer)
+    }
+  }, [])
+
+  const scrollToPrinciple = (index: number) => {
+    const container = cardsRef.current
+    const card = container?.children[index] as HTMLElement | undefined
+
+    if (!container || !card) return
+
+    container.scrollTo({
+      left: card.offsetLeft,
+      behavior: 'smooth',
+    })
+  }
+
   return (
     <SectionWrapper id="method" background="muted" animate={false}>
       <div ref={sectionRef}>
@@ -72,19 +129,19 @@ export function MethodSection() {
         {/* Philosophy quote */}
         <div 
           className={cn(
-            'mx-auto mb-16 max-w-3xl relative transition-all duration-700',
+            'relative mx-auto mb-10 max-w-3xl transition-all duration-700 md:mb-16',
             isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
           )}
         >
-          <div className="absolute -top-6 left-8 text-primary/20">
-            <Quote className="h-16 w-16" />
+          <div className="absolute -top-4 left-5 text-primary/20 md:-top-6 md:left-8">
+            <Quote className="h-12 w-12 md:h-16 md:w-16" />
           </div>
-          <div className="rounded-2xl bg-card border border-border/50 p-8 md:p-12 shadow-lg relative">
+          <div className="relative rounded-2xl border border-border/50 bg-card p-6 shadow-lg md:p-12">
             <blockquote className="text-center">
-              <p className="font-serif text-xl text-foreground md:text-2xl leading-relaxed">
+              <p className="font-serif text-lg leading-relaxed text-foreground md:text-2xl">
                 {trainer.philosophy}
               </p>
-              <footer className="mt-6 flex items-center justify-center gap-3">
+              <footer className="mt-5 flex items-center justify-center gap-3 md:mt-6">
                 <div className="h-px w-12 bg-primary/30" />
                 <span className="text-sm font-semibold text-primary">{trainer.name}</span>
                 <div className="h-px w-12 bg-primary/30" />
@@ -94,33 +151,68 @@ export function MethodSection() {
         </div>
 
         {/* Principles grid */}
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mb-4 flex items-center justify-between gap-3 px-1 sm:hidden">
+          <div>
+            <p className="font-serif text-[1.1rem] font-semibold leading-tight tracking-tight text-foreground">
+              6 ключевых принципов
+            </p>
+          </div>
+          <div className="min-h-5">
+            {showSwipeHint && (
+              <p className="flex items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                <span>листайте</span>
+                <span className="inline-block motion-safe:animate-[swipe-hint_1.8s_ease-in-out_infinite]">→</span>
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div
+          ref={cardsRef}
+          className="flex snap-x snap-mandatory gap-4 overflow-x-auto px-1 pt-2 pb-5 no-scrollbar overscroll-x-contain sm:grid sm:grid-cols-2 sm:gap-6 sm:overflow-visible sm:px-0 sm:pt-0 sm:pb-0 lg:grid-cols-3"
+        >
           {principles.map((principle, index) => (
             <div
               key={principle.number}
               className={cn(
-                'group relative rounded-2xl border border-border/50 bg-card p-8 transition-all duration-500 hover:border-primary/30 hover:shadow-xl hover:-translate-y-1',
+                'group relative basis-full shrink-0 snap-start rounded-[1.75rem] border border-border/50 bg-card p-6 shadow-[0_18px_40px_-32px_rgba(41,25,15,0.32)] transition-all duration-500 hover:border-primary/30 hover:shadow-xl sm:basis-auto sm:rounded-2xl sm:p-7 lg:p-8 lg:hover:-translate-y-1',
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
               )}
               style={{ transitionDelay: isVisible ? `${index * 100}ms` : '0ms' }}
             >
               {/* Number badge */}
-              <div className="absolute -top-3 -left-3 h-10 w-10 rounded-xl bg-primary flex items-center justify-center shadow-lg shadow-primary/25">
+              <div className="absolute left-5 top-5 flex h-10 w-10 items-center justify-center rounded-xl bg-primary shadow-lg shadow-primary/25 sm:-left-3 sm:-top-3 sm:h-10 sm:w-10">
                 <span className="text-sm font-bold text-primary-foreground">
                   {principle.number}
                 </span>
               </div>
               
-              <h3 className="mt-2 font-serif text-xl font-semibold text-foreground">
+              <h3 className="mt-14 font-serif text-[1.7rem] leading-none font-semibold text-foreground sm:mt-2 sm:text-xl">
                 {principle.title}
               </h3>
-              <p className="mt-3 text-muted-foreground leading-relaxed">
+              <p className="mt-4 min-h-[4.5rem] text-base leading-relaxed text-muted-foreground sm:min-h-0 sm:text-base">
                 {principle.description}
               </p>
               
               {/* Hover gradient */}
-              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-primary/5 via-transparent to-accent/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-primary/5 via-transparent to-accent/5 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
             </div>
+          ))}
+        </div>
+
+        <div className="mt-4 flex items-center justify-center gap-2 sm:hidden">
+          {principles.map((principle, index) => (
+            <button
+              key={principle.number}
+              type="button"
+              aria-label={`Перейти к принципу ${principle.number}`}
+              aria-current={activePrinciple === index}
+              onClick={() => scrollToPrinciple(index)}
+              className={cn(
+                'h-1.5 rounded-full bg-primary/20 transition-all duration-300',
+                activePrinciple === index ? 'w-6 bg-primary' : 'w-1.5'
+              )}
+            />
           ))}
         </div>
       </div>

--- a/components/sections/testimonials-section.tsx
+++ b/components/sections/testimonials-section.tsx
@@ -11,7 +11,9 @@ import { cn } from '@/lib/utils'
 export function TestimonialsSection() {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isVisible, setIsVisible] = useState(false)
+  const [quoteMinHeight, setQuoteMinHeight] = useState(0)
   const sectionRef = useRef<HTMLDivElement>(null)
+  const measureRefs = useRef<(HTMLParagraphElement | null)[]>([])
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -28,6 +30,26 @@ export function TestimonialsSection() {
     }
 
     return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const measureQuoteHeight = () => {
+      const heights = measureRefs.current
+        .map((element) => element?.getBoundingClientRect().height ?? 0)
+        .filter(Boolean)
+
+      if (heights.length > 0) {
+        setQuoteMinHeight(Math.ceil(Math.max(...heights)))
+      }
+    }
+
+    const animationFrame = window.requestAnimationFrame(measureQuoteHeight)
+    window.addEventListener('resize', measureQuoteHeight)
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame)
+      window.removeEventListener('resize', measureQuoteHeight)
+    }
   }, [])
 
   const nextTestimonial = () => {
@@ -55,23 +77,40 @@ export function TestimonialsSection() {
             isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
           )}
         >
-          <div className="relative rounded-3xl bg-card border border-border/50 p-8 md:p-12 shadow-xl">
+          <div className="relative rounded-[2rem] border border-border/50 bg-card p-5 shadow-xl sm:p-6 md:rounded-3xl md:p-12">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute left-5 right-5 top-16 opacity-0 sm:left-6 sm:right-6 sm:top-20 md:left-12 md:right-12 md:top-24"
+            >
+              {testimonials.map((testimonial, index) => (
+                <p
+                  key={testimonial.id}
+                  ref={(element) => {
+                    measureRefs.current[index] = element
+                  }}
+                  className="font-serif text-lg leading-relaxed text-foreground sm:text-xl md:text-2xl"
+                >
+                  "{testimonial.text}"
+                </p>
+              ))}
+            </div>
+
             {/* Quote icon */}
-            <div className="absolute left-8 top-8 md:left-12 md:top-12">
-              <div className="h-16 w-16 rounded-full bg-primary/10 flex items-center justify-center">
-                <Quote className="h-8 w-8 text-primary" />
+            <div className="absolute left-5 top-5 sm:left-6 sm:top-6 md:left-12 md:top-12">
+              <div className="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 sm:h-12 sm:w-12 md:h-16 md:w-16">
+                <Quote className="h-5 w-5 text-primary sm:h-6 sm:w-6 md:h-8 md:w-8" />
               </div>
             </div>
 
             {/* Content */}
-            <div className="relative pt-16 md:pt-12">
+            <div className="relative pt-10 sm:pt-12 md:pt-12">
               {/* Stars */}
-              <div className="mb-6 flex justify-center gap-1">
+              <div className="mb-4 flex justify-center gap-1 sm:mb-5 md:mb-6">
                 {[...Array(5)].map((_, i) => (
                   <Star
                     key={i}
                     className={cn(
-                      'h-6 w-6 transition-all duration-300',
+                      'h-5 w-5 transition-all duration-300 md:h-6 md:w-6',
                       i < currentTestimonial.rating
                         ? 'fill-primary text-primary'
                         : 'text-muted-foreground/30'
@@ -81,30 +120,33 @@ export function TestimonialsSection() {
               </div>
 
               {/* Text */}
-              <blockquote className="text-center">
-                <p className="font-serif text-xl text-foreground md:text-2xl leading-relaxed">
+              <blockquote
+                className="flex items-center justify-center text-center"
+                style={quoteMinHeight > 0 ? { minHeight: `${quoteMinHeight}px` } : undefined}
+              >
+                <p className="font-serif text-lg leading-relaxed text-foreground sm:text-xl md:text-2xl">
                   "{currentTestimonial.text}"
                 </p>
               </blockquote>
 
               {/* Author */}
-              <div className="mt-10 flex flex-col items-center">
-                <div className="h-16 w-16 rounded-full bg-gradient-to-br from-primary/20 to-accent/20 flex items-center justify-center ring-4 ring-background">
-                  <span className="font-serif text-xl font-semibold text-primary">
+              <div className="mt-6 flex flex-col items-center sm:mt-8 md:mt-10">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-primary/20 to-accent/20 ring-4 ring-background sm:h-14 sm:w-14 md:h-16 md:w-16">
+                  <span className="font-serif text-lg font-semibold text-primary sm:text-xl">
                     {currentTestimonial.name.charAt(0)}
                   </span>
                 </div>
-                <p className="mt-4 font-semibold text-foreground text-lg">
+                <p className="mt-3 text-base font-semibold text-foreground sm:mt-4 sm:text-lg">
                   {currentTestimonial.name}
                 </p>
                 {currentTestimonial.occupation && (
-                  <p className="text-sm text-muted-foreground">
+                  <p className="hidden text-sm text-muted-foreground sm:block">
                     {currentTestimonial.occupation}
                     {currentTestimonial.age && `, ${currentTestimonial.age} лет`}
                   </p>
                 )}
                 {currentTestimonial.date && (
-                  <p className="mt-1 text-xs text-muted-foreground/70">
+                  <p className="mt-1 hidden text-xs text-muted-foreground/70 sm:block">
                     {currentTestimonial.date}
                   </p>
                 )}
@@ -112,12 +154,12 @@ export function TestimonialsSection() {
             </div>
 
             {/* Navigation */}
-            <div className="mt-10 flex items-center justify-center gap-6">
+            <div className="mt-6 flex items-center justify-center gap-3 sm:mt-8 sm:gap-4 md:mt-10 md:gap-6">
               <Button
                 variant="outline"
                 size="icon"
                 onClick={prevTestimonial}
-                className="h-12 w-12 rounded-full border-border/50 hover:bg-primary hover:text-primary-foreground hover:border-primary transition-all duration-300"
+                className="h-10 w-10 rounded-full border-border/50 transition-all duration-300 hover:border-primary hover:bg-primary hover:text-primary-foreground md:h-12 md:w-12"
               >
                 <ChevronLeft className="h-5 w-5" />
                 <span className="sr-only">Предыдущий отзыв</span>
@@ -130,10 +172,10 @@ export function TestimonialsSection() {
                     key={index}
                     onClick={() => setCurrentIndex(index)}
                     className={cn(
-                      'h-2.5 rounded-full transition-all duration-300',
+                      'h-2 rounded-full transition-all duration-300 md:h-2.5',
                       index === currentIndex
-                        ? 'w-8 bg-primary'
-                        : 'w-2.5 bg-muted-foreground/30 hover:bg-muted-foreground/50'
+                        ? 'w-6 bg-primary md:w-8'
+                        : 'w-2 bg-muted-foreground/30 hover:bg-muted-foreground/50 md:w-2.5'
                     )}
                   >
                     <span className="sr-only">Отзыв {index + 1}</span>
@@ -145,7 +187,7 @@ export function TestimonialsSection() {
                 variant="outline"
                 size="icon"
                 onClick={nextTestimonial}
-                className="h-12 w-12 rounded-full border-border/50 hover:bg-primary hover:text-primary-foreground hover:border-primary transition-all duration-300"
+                className="h-10 w-10 rounded-full border-border/50 transition-all duration-300 hover:border-primary hover:bg-primary hover:text-primary-foreground md:h-12 md:w-12"
               >
                 <ChevronRight className="h-5 w-5" />
                 <span className="sr-only">Следующий отзыв</span>
@@ -155,7 +197,7 @@ export function TestimonialsSection() {
         </div>
 
         {/* All testimonials grid (smaller) */}
-        <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-12 hidden gap-4 sm:grid sm:grid-cols-2 lg:grid-cols-3">
           {testimonials.slice(0, 3).map((testimonial, index) => (
             <button
               key={testimonial.id}

--- a/components/sections/testimonials-section.tsx
+++ b/components/sections/testimonials-section.tsx
@@ -139,6 +139,16 @@ export function TestimonialsSection() {
                 <p className="mt-3 text-base font-semibold text-foreground sm:mt-4 sm:text-lg">
                   {currentTestimonial.name}
                 </p>
+                <div className="mt-1 text-center sm:hidden">
+                  {(currentTestimonial.occupation || currentTestimonial.date) && (
+                    <p className="text-[13px] leading-snug text-muted-foreground">
+                      {currentTestimonial.occupation}
+                      {currentTestimonial.age && `, ${currentTestimonial.age} лет`}
+                      {currentTestimonial.occupation && currentTestimonial.date && ' · '}
+                      {currentTestimonial.date}
+                    </p>
+                  )}
+                </div>
                 {currentTestimonial.occupation && (
                   <p className="hidden text-sm text-muted-foreground sm:block">
                     {currentTestimonial.occupation}

--- a/components/shared/theme-toggle.tsx
+++ b/components/shared/theme-toggle.tsx
@@ -3,11 +3,10 @@
 import * as React from 'react'
 import { Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
-import { flushSync } from 'react-dom'
 import { Button } from '@/components/ui/button'
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme()
+  const { resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = React.useState(false)
 
   React.useEffect(() => {
@@ -15,7 +14,7 @@ export function ThemeToggle() {
   }, [])
 
   const toggleTheme = () => {
-    const nextTheme = theme === 'light' ? 'dark' : 'light'
+    const nextTheme = resolvedTheme === 'dark' ? 'light' : 'dark'
     const startViewTransition = (
       document as Document & {
         startViewTransition?: (callback: () => void | Promise<void>) => void
@@ -27,9 +26,11 @@ export function ThemeToggle() {
       return
     }
 
-    startViewTransition(() => {
-      flushSync(() => {
-        setTheme(nextTheme)
+    startViewTransition(async () => {
+      setTheme(nextTheme)
+
+      await new Promise<void>((resolve) => {
+        window.requestAnimationFrame(() => resolve())
       })
     })
   }
@@ -52,7 +53,7 @@ export function ThemeToggle() {
       <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
       <span className="sr-only">
-        {theme === 'light' ? 'Включить тёмную тему' : 'Включить светлую тему'}
+        {resolvedTheme === 'light' ? 'Включить тёмную тему' : 'Включить светлую тему'}
       </span>
     </Button>
   )

--- a/components/shared/theme-toggle.tsx
+++ b/components/shared/theme-toggle.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
+import { flushSync } from 'react-dom'
 import { Button } from '@/components/ui/button'
 
 export function ThemeToggle() {
@@ -12,6 +13,26 @@ export function ThemeToggle() {
   React.useEffect(() => {
     setMounted(true)
   }, [])
+
+  const toggleTheme = () => {
+    const nextTheme = theme === 'light' ? 'dark' : 'light'
+    const startViewTransition = (
+      document as Document & {
+        startViewTransition?: (callback: () => void | Promise<void>) => void
+      }
+    ).startViewTransition
+
+    if (!startViewTransition) {
+      setTheme(nextTheme)
+      return
+    }
+
+    startViewTransition(() => {
+      flushSync(() => {
+        setTheme(nextTheme)
+      })
+    })
+  }
 
   if (!mounted) {
     return (
@@ -26,7 +47,7 @@ export function ThemeToggle() {
       variant="ghost"
       size="icon"
       className="h-9 w-9"
-      onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+      onClick={toggleTheme}
     >
       <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />


### PR DESCRIPTION
### Motivation

- Improve responsive layouts and interactions for the hero, benefits, method and testimonials sections to provide a smoother mobile experience and more consistent visual rhythm.  
- Add a smoother theme toggle transition using the View Transition API where available and guard for reduced-motion preferences.  
- Provide small UI utilities (no-scrollbar, swipe hint animation) and global color/transition tweaks to improve perceived performance and polish.

### Description

- Additions to `app/globals.css`: enable `transition-colors` on `body`, add `.no-scrollbar` utility, `swipe-hint` animation, and `::view-transition` keyframes with reduced-motion handling.  
- Theme toggle: replace direct `setTheme` usage with `startViewTransition` wrapper in `components/shared/theme-toggle.tsx` and use `flushSync` to ensure synchronous state update when available.  
- Hero section: major responsive refactor in `components/sections/hero-section.tsx` to provide separate mobile card and desktop text card layouts, image handling, spacing and CTA adjustments.  
- Method section: implement a horizontally-scrollable, snap-enabled cards layout on small screens with active indicator, swipe hint and programmatic `scrollToPrinciple` in `components/sections/method-section.tsx`.  
- Testimonials section: stabilize featured quote height by measuring testimonial variants, adjust responsive spacing and controls, and hide the small-grid list on mobile in `components/sections/testimonials-section.tsx`.  
- Benefits section: tweak grid, spacing, card sizing and typographic scales in `components/sections/benefits-section.tsx`.  
- Minor: remove `disableTransitionOnChange` prop from `ThemeProvider` in `app/layout.tsx` to allow view transitions to apply.

### Testing

- Type checking was run with `tsc --noEmit` and succeeded.  
- Linting was run with `eslint` and returned no blocking errors.  
- A production build was performed with `next build` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bff588e4d4832597f81ba78ae7e92e)