### PR TITLE
Update social preview metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,21 +3,28 @@ import { Analytics } from '@vercel/analytics/next'
 import { ThemeProvider } from '@/components/theme-provider'
 import './globals.css'
 
+const siteTitle = 'Pilatta — студия пилатеса в Москве'
+const siteDescription = 'Pilatta — студия пилатеса в Москве: персональные занятия, мини-группы, онлайн-тренировки и программы для беременных. Запишитесь на пробное занятие.'
+const siteUrl = 'https://v0-pilates-studio-website-pink.vercel.app'
+
 export const metadata: Metadata = {
-  title: 'Pilatta | Студия пилатеса в Москве',
-  description: 'Студия пилатеса Pilatta в Москве: персональные занятия, мини-группы, онлайн-тренировки и программы для беременных. Запишитесь на пробное занятие.',
+  metadataBase: new URL(siteUrl),
+  title: siteTitle,
+  description: siteDescription,
   keywords: ['пилатес', 'Pilatta', 'студия пилатеса', 'персональные тренировки', 'групповые занятия', 'Москва'],
   authors: [{ name: 'Pilatta' }],
   openGraph: {
-    title: 'Pilatta | Студия пилатеса',
-    description: 'Pilatta — студия пилатеса в Москве с персональными занятиями, мини-группами, онлайн-тренировками и программами для беременных.',
+    title: siteTitle,
+    description: siteDescription,
+    url: siteUrl,
+    siteName: 'Pilatta',
     type: 'website',
     locale: 'ru_RU',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Pilatta | Студия пилатеса',
-    description: 'Pilatta — студия пилатеса в Москве с персональными занятиями, мини-группами, онлайн-тренировками и программами для беременных.',
+    title: siteTitle,
+    description: siteDescription,
   },
 }
 


### PR DESCRIPTION
### Motivation
- Replace outdated link-preview text (previously showing "студия ксении") with the current site title and description so social/messaging previews display the correct branding.
- Ensure Open Graph and Twitter metadata are consistent and include a canonical site URL to reduce variability in external previews.

### Description
- Updated `app/layout.tsx` to introduce `siteTitle`, `siteDescription`, and `siteUrl` constants and use them for metadata.
- Added `metadataBase: new URL(siteUrl)`, set `openGraph.url` and `openGraph.siteName`, and synchronized `openGraph` and `twitter` fields to use the new constants.
- Centralized title/description into a single source of truth so social previews and page metadata remain consistent.

### Testing
- Ran `npm run build` which completed successfully and prerendered static pages.
- Ran `npm run lint` which failed due to missing ESLint configuration required by ESLint v9 (no `eslint.config.*` present).
- No additional automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c018ae510483259a453995b7d94a21)