### PR TITLE
fix(ui): убрать мерцание CTA и кнопки Кабинет на первом рендере

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,11 +11,36 @@ import { TestimonialsSection } from '@/components/sections/testimonials-section'
 import { FAQSection } from '@/components/sections/faq-section'
 import { StudioSection } from '@/components/sections/studio-section'
 import { ContactSection } from '@/components/sections/contact-section'
+import { createClient } from '@/lib/supabase/server'
 
-export default function Home() {
+export default async function Home() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  let initialUserStatus = {
+    isAuthenticated: false,
+    role: null as string | null,
+    bookingCount: 0,
+  }
+
+  if (user) {
+    const [profileResult, bookingsResult] = await Promise.all([
+      supabase.from('users_profile').select('role').eq('id', user.id).single(),
+      supabase.from('bookings').select('id', { count: 'exact', head: true }).eq('user_id', user.id),
+    ])
+
+    initialUserStatus = {
+      isAuthenticated: true,
+      role: profileResult.data?.role ?? 'user',
+      bookingCount: bookingsResult.count ?? 0,
+    }
+  }
+
   return (
     <>
-      <Header />
+      <Header initialUserStatus={initialUserStatus} />
       <main>
         <HeroSection />
         <AboutSection />

--- a/components/layout/auth-nav.tsx
+++ b/components/layout/auth-nav.tsx
@@ -3,25 +3,37 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
-import { User } from '@supabase/supabase-js'
 import { Button } from '@/components/ui/button'
 import { LogIn, User as UserIcon, LogOut } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useRouter } from 'next/navigation'
 import { getUserStatusAction } from '@/lib/actions/user'
 
-export function AuthNav({ className, isMobile = false }: { className?: string, isMobile?: boolean }) {
-  const [user, setUser] = useState<User | null>(null)
-  const [loading, setLoading] = useState(true)
+interface AuthState {
+  isAuthenticated: boolean
+  role: string | null
+}
+
+export function AuthNav({
+  className,
+  isMobile = false,
+  initialAuthState,
+}: {
+  className?: string
+  isMobile?: boolean
+  initialAuthState?: AuthState
+}) {
+  const [isAuthenticated, setIsAuthenticated] = useState(Boolean(initialAuthState?.isAuthenticated))
+  const [loading, setLoading] = useState(initialAuthState ? false : true)
   const supabase = createClient()
   const router = useRouter()
 
-  const [role, setRole] = useState<string | null>(null)
+  const [role, setRole] = useState<string | null>(initialAuthState?.role ?? null)
 
   useEffect(() => {
     // Получаем текущего пользователя и его статус
     supabase.auth.getUser().then(({ data }) => {
-      setUser(data.user)
+      setIsAuthenticated(Boolean(data.user))
       if (data.user) {
         getUserStatusAction().then(status => {
           setRole(status.role)
@@ -35,7 +47,7 @@ export function AuthNav({ className, isMobile = false }: { className?: string, i
     // Подписываемся на изменения состояния авторизации
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       (event, session) => {
-        setUser(session?.user ?? null)
+        setIsAuthenticated(Boolean(session?.user))
         router.refresh()
       }
     )
@@ -55,7 +67,7 @@ export function AuthNav({ className, isMobile = false }: { className?: string, i
     return <div className={cn("h-10 w-24 animate-pulse rounded-md bg-muted", className)} />
   }
 
-  if (user) {
+  if (isAuthenticated) {
     return (
       <div className={cn("flex items-center gap-2", isMobile ? "flex-col w-full" : "", className)}>
         <Button variant="outline" className={cn(isMobile ? "w-full justify-start" : "")} asChild>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -29,7 +29,15 @@ const navItems = [
   { label: 'Контакты', href: '#contact' },
 ]
 
-export function Header() {
+interface HeaderProps {
+  initialUserStatus?: {
+    isAuthenticated: boolean
+    role: string | null
+    bookingCount: number
+  }
+}
+
+export function Header({ initialUserStatus }: HeaderProps) {
   const [isScrolled, setIsScrolled] = useState(false)
   const [activeSection, setActiveSection] = useState('')
 
@@ -107,8 +115,29 @@ export function Header() {
           <div className="flex items-center gap-3">
             <ThemeToggle />
             <div className="hidden lg:flex items-center gap-3">
-              <AuthNav />
-              <CTAButton size="default" />
+              <AuthNav
+                initialAuthState={
+                  initialUserStatus
+                    ? {
+                        isAuthenticated: initialUserStatus.isAuthenticated,
+                        role: initialUserStatus.role,
+                      }
+                    : undefined
+                }
+              />
+              <CTAButton
+                size="default"
+                initialVisible={
+                  initialUserStatus
+                    ? !(
+                        initialUserStatus.isAuthenticated &&
+                        (initialUserStatus.role === 'admin' ||
+                          initialUserStatus.role === 'trainer' ||
+                          initialUserStatus.bookingCount > 0)
+                      )
+                    : undefined
+                }
+              />
             </div>
             <div className="lg:hidden">
               <MobileNav navItems={navItems} />

--- a/components/shared/cta-button.tsx
+++ b/components/shared/cta-button.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, Loader2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { getUserStatusAction } from '@/lib/actions/user'
 
@@ -12,6 +12,7 @@ interface CTAButtonProps {
   className?: string
   children?: React.ReactNode
   showArrow?: boolean
+  initialVisible?: boolean
 }
 
 export function CTAButton({
@@ -20,12 +21,17 @@ export function CTAButton({
   className,
   children = 'Записаться на пробное',
   showArrow = true,
+  initialVisible,
 }: CTAButtonProps) {
-  const [isVisible, setIsVisible] = useState(true)
+  const isTrialCta = children === 'Записаться на пробное'
+  const [isVisible, setIsVisible] = useState(
+    initialVisible !== undefined ? initialVisible : !isTrialCta ? true : false
+  )
+  const [isChecking, setIsChecking] = useState(isTrialCta && initialVisible === undefined)
 
   useEffect(() => {
     // Only apply visibility logic if it's the default "book a trial" button
-    if (children === 'Записаться на пробное') {
+    if (isTrialCta && initialVisible === undefined) {
       const checkVisibility = async () => {
         const status = await getUserStatusAction()
         if (
@@ -33,11 +39,14 @@ export function CTAButton({
           (status.role === 'admin' || status.role === 'trainer' || status.bookingCount > 0)
         ) {
           setIsVisible(false)
+        } else {
+          setIsVisible(true)
         }
+        setIsChecking(false)
       }
       checkVisibility()
     }
-  }, [children])
+  }, [isTrialCta, initialVisible])
 
   const handleClick = () => {
     const contactSection = document.getElementById('contact')
@@ -50,6 +59,21 @@ export function CTAButton({
         }
       }, 800)
     }
+  }
+
+  if (isChecking) {
+    return (
+      <Button
+        variant={variant}
+        size={size}
+        disabled
+        aria-busy="true"
+        className={cn('font-semibold gap-2', className)}
+      >
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span>Загрузка...</span>
+      </Button>
+    )
   }
 
   if (!isVisible) return null


### PR DESCRIPTION
Refs #49

## Что сделано
- добавлен server-first расчёт initial user status на главной странице;
- прокинут initial status в Header для стабильного первого кадра;
- в AuthNav добавлено initialAuthState, чтобы убрать промежуточный визуальный state;
- в CTAButton добавлены initialVisible и loading-state вместо схемы "показать, потом скрыть".

## Изменённые файлы
- app/page.tsx
- components/layout/header.tsx
- components/layout/auth-nav.tsx
- components/shared/cta-button.tsx

## Проверки
- IDE diagnostics: без ошибок в изменённых файлах.
- `pnpm lint`: не выполнен корректно, так как в проекте отсутствует пакет `eslint` (скрипт есть, зависимости нет).
- Runtime/visual проверка рекомендуется на desktop и mobile.