### PR TITLE
fix(admin): исправить 404 профиля пользователя и добавить редактирование

### DIFF
--- a/app/admin/session-types/[id]/edit/edit-form.tsx
+++ b/app/admin/session-types/[id]/edit/edit-form.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Save, Loader2 } from "lucide-react";
+import { updateSessionTypeAction } from "@/lib/actions/admin";
+
+type SessionType = {
+  id: string;
+  title: string;
+  description: string | null;
+  default_price: number;
+  default_capacity: number;
+  default_duration_minutes: number;
+};
+
+export function EditSessionTypeForm({ sessionType }: { sessionType: SessionType }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [form, setForm] = useState({
+    title: sessionType.title,
+    description: sessionType.description ?? "",
+    default_price: sessionType.default_price,
+    default_capacity: sessionType.default_capacity,
+    default_duration_minutes: sessionType.default_duration_minutes,
+  });
+
+  const inputClass =
+    "w-full px-4 py-2.5 rounded-xl border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary/40";
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.title.trim()) {
+      toast.error("Название обязательно");
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await updateSessionTypeAction(sessionType.id, {
+        title: form.title.trim(),
+        description: form.description.trim() || undefined,
+        default_price: Number(form.default_price),
+        default_capacity: Number(form.default_capacity),
+        default_duration_minutes: Number(form.default_duration_minutes),
+      });
+
+      if (result.error) {
+        toast.error("Ошибка обновления", { description: result.error });
+        return;
+      }
+
+      toast.success("Тип занятия обновлен");
+      router.push("/admin/session-types");
+      router.refresh();
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-2xl border bg-card/60 backdrop-blur-sm p-6 shadow-sm space-y-4">
+      <div className="space-y-1.5">
+        <label className="text-sm font-medium text-muted-foreground">Название *</label>
+        <input
+          value={form.title}
+          onChange={(e) => setForm((prev) => ({ ...prev, title: e.target.value }))}
+          className={inputClass}
+          required
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-sm font-medium text-muted-foreground">Описание</label>
+        <textarea
+          value={form.description}
+          onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+          className={`${inputClass} resize-none`}
+          rows={3}
+        />
+      </div>
+
+      <div className="grid md:grid-cols-3 gap-3">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-muted-foreground">Цена (₽)</label>
+          <input
+            type="number"
+            min={0}
+            value={form.default_price}
+            onChange={(e) => setForm((prev) => ({ ...prev, default_price: Number(e.target.value) }))}
+            className={inputClass}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-muted-foreground">Мест</label>
+          <input
+            type="number"
+            min={1}
+            value={form.default_capacity}
+            onChange={(e) => setForm((prev) => ({ ...prev, default_capacity: Number(e.target.value) }))}
+            className={inputClass}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-muted-foreground">Длительность (мин)</label>
+          <input
+            type="number"
+            min={1}
+            value={form.default_duration_minutes}
+            onChange={(e) => setForm((prev) => ({ ...prev, default_duration_minutes: Number(e.target.value) }))}
+            className={inputClass}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between pt-1">
+        <button
+          type="button"
+          onClick={() => router.push("/admin/session-types")}
+          className="px-5 py-2.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Назад
+        </button>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="inline-flex items-center gap-2 px-5 py-2.5 bg-primary text-primary-foreground text-sm font-medium rounded-full disabled:opacity-60"
+        >
+          {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+          {isPending ? "Сохранение..." : "Сохранить"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/admin/session-types/[id]/edit/page.tsx
+++ b/app/admin/session-types/[id]/edit/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { redirect, notFound } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { EditSessionTypeForm } from "./edit-form";
+
+export const metadata = { title: "Редактировать тип занятия | Pilatta Admin" };
+
+export default async function EditSessionTypePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const adminDb = createAdminClient();
+  const { data: sessionType } = await adminDb
+    .from("session_types")
+    .select("id, title, description, default_price, default_capacity, default_duration_minutes, is_active")
+    .eq("id", id)
+    .eq("is_active", true)
+    .single();
+
+  if (!sessionType) notFound();
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div className="flex items-center gap-3">
+        <Link
+          href="/admin/session-types"
+          className="p-2 rounded-xl hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="w-4 h-4" />
+        </Link>
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Редактировать тип занятия</h1>
+          <p className="text-muted-foreground mt-0.5 text-sm">{sessionType.title}</p>
+        </div>
+      </div>
+
+      <EditSessionTypeForm sessionType={sessionType} />
+    </div>
+  );
+}

--- a/app/admin/session-types/session-types-client.tsx
+++ b/app/admin/session-types/session-types-client.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
 import { Plus, Edit2, Trash2, X, Check, Dumbbell } from "lucide-react";
 import { createSessionTypeAction, updateSessionTypeAction, deleteSessionTypeAction } from "@/lib/actions/admin";
+import Link from "next/link";
 
 type SessionType = {
   id: string;
@@ -149,13 +150,23 @@ export function SessionTypesClient({ sessionTypes }: { sessionTypes: SessionType
               <div className="p-2 bg-primary/10 rounded-xl">
                 <Dumbbell className="w-4 h-4 text-primary" />
               </div>
-              <button
-                onClick={() => handleDelete(st.id)}
-                disabled={isPending}
-                className="p-1.5 rounded-lg hover:bg-destructive/10 hover:text-destructive transition-colors"
-              >
-                <Trash2 className="w-4 h-4" />
-              </button>
+              <div className="flex items-center gap-1">
+                <Link
+                  href={`/admin/session-types/${st.id}/edit`}
+                  className="p-1.5 rounded-lg hover:bg-primary/10 hover:text-primary transition-colors"
+                  title="Редактировать тип"
+                >
+                  <Edit2 className="w-4 h-4" />
+                </Link>
+                <button
+                  onClick={() => handleDelete(st.id)}
+                  disabled={isPending}
+                  className="p-1.5 rounded-lg hover:bg-destructive/10 hover:text-destructive transition-colors"
+                  title="Деактивировать тип"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
             </div>
             <h3 className="font-semibold mb-1">{st.title}</h3>
             {st.description && <p className="text-xs text-muted-foreground mb-3 line-clamp-2">{st.description}</p>}

--- a/app/admin/sessions/[id]/edit/page.tsx
+++ b/app/admin/sessions/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
@@ -6,15 +7,17 @@ import { EditSessionForm } from "./edit-form";
 
 export const metadata = { title: "Редактировать занятие | Pilatta Admin" };
 
-export default async function EditSessionPage({ params }: { params: { id: string } }) {
+export default async function EditSessionPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
   const supabase = await createClient();
+  const adminDb = createAdminClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/sign-in");
 
   const [{ data: session }, { data: sessionTypes }, { data: trainers }] = await Promise.all([
-    supabase.from("sessions").select("*").eq("id", params.id).single(),
-    supabase.from("session_types").select("id, title, default_price, default_capacity").eq("is_active", true),
-    supabase.from("users_profile").select("id, first_name, last_name").in("role", ["trainer", "admin"]),
+    adminDb.from("sessions").select("*").eq("id", id).single(),
+    adminDb.from("session_types").select("id, title, default_price, default_capacity").eq("is_active", true),
+    adminDb.from("users_profile").select("id, first_name, last_name").in("role", ["trainer", "admin"]),
   ]);
 
   if (!session) return notFound();

--- a/app/admin/users/[id]/page.tsx
+++ b/app/admin/users/[id]/page.tsx
@@ -1,23 +1,26 @@
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, Mail, Phone, MapPin, Calendar } from "lucide-react";
 import { format } from "date-fns";
 import { ru } from "date-fns/locale";
+import { UserEditForm } from "./user-edit-form";
 
 export default async function AdminUserDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const supabase = await createClient();
+  const adminDb = createAdminClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/sign-in");
 
   const [{ data: profile }, { data: bookings }] = await Promise.all([
-    supabase
+    adminDb
       .from("users_profile")
       .select("*")
       .eq("id", id)
       .single(),
-    supabase
+    adminDb
       .from("bookings")
       .select("id, status, booked_at, is_paid, sessions(title, start_time, location)")
       .eq("user_id", id)
@@ -94,6 +97,19 @@ export default async function AdminUserDetailPage({ params }: { params: Promise<
             </div>
           </div>
         </div>
+
+        <UserEditForm
+          userId={profile.id}
+          initialValues={{
+            first_name: profile.first_name ?? "",
+            last_name: profile.last_name ?? "",
+            phone: profile.phone ?? "",
+            city: profile.city ?? "",
+            country: profile.country ?? "",
+            role: profile.role ?? "user",
+            status: profile.status ?? "active",
+          }}
+        />
       </div>
 
       {/* Bookings */}

--- a/app/admin/users/[id]/user-edit-form.tsx
+++ b/app/admin/users/[id]/user-edit-form.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { updateUserProfileAdminAction } from "@/lib/actions/admin";
+
+type UserEditValues = {
+  first_name: string;
+  last_name: string;
+  phone: string;
+  city: string;
+  country: string;
+  role: "user" | "client" | "trainer" | "admin";
+  status: "active" | "blocked";
+};
+
+const ROLES: Array<UserEditValues["role"]> = ["user", "client", "trainer", "admin"];
+
+export function UserEditForm({
+  userId,
+  initialValues,
+}: {
+  userId: string;
+  initialValues: UserEditValues;
+}) {
+  const [form, setForm] = useState<UserEditValues>(initialValues);
+  const [isPending, startTransition] = useTransition();
+
+  const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    startTransition(async () => {
+      const result = await updateUserProfileAdminAction(userId, form);
+      if (result.error) {
+        toast.error("Ошибка обновления", { description: result.error });
+        return;
+      }
+      toast.success("Данные пользователя обновлены");
+    });
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="rounded-2xl border bg-card/60 backdrop-blur-sm p-6 shadow-sm space-y-4">
+      <h2 className="font-semibold">Редактирование профиля</h2>
+
+      <div className="grid grid-cols-2 gap-3">
+        <label className="space-y-1 text-sm">
+          <span className="text-muted-foreground">Имя</span>
+          <input
+            value={form.first_name}
+            onChange={(e) => setForm((prev) => ({ ...prev, first_name: e.target.value }))}
+            className="w-full rounded-lg border bg-background px-3 py-2"
+          />
+        </label>
+        <label className="space-y-1 text-sm">
+          <span className="text-muted-foreground">Фамилия</span>
+          <input
+            value={form.last_name}
+            onChange={(e) => setForm((prev) => ({ ...prev, last_name: e.target.value }))}
+            className="w-full rounded-lg border bg-background px-3 py-2"
+          />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <label className="space-y-1 text-sm">
+          <span className="text-muted-foreground">Телефон</span>
+          <input
+            value={form.phone}
+            onChange={(e) => setForm((prev) => ({ ...prev, phone: e.target.value }))}
+            className="w-full rounded-lg border bg-background px-3 py-2"
+          />
+        </label>
+        <label className="space-y-1 text-sm">
+          <span className="text-muted-foreground">Город</span>
+          <input
+            value={form.city}
+            onChange={(e) => setForm((prev) => ({ ...prev, city: e.target.value }))}
+            className="w-full rounded-lg border bg-background px-3 py-2"
+          />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <label className="space-y-1 text-sm">
+          <span className="text-muted-foreground">Страна</span>
+          <input
+            value={form.country}
+            onChange={(e) => setForm((prev) => ({ ...prev, country: e.target.value }))}
+            className="w-full rounded-lg border bg-background px-3 py-2"
+          />
+        </label>
+        <label className="space-y-1 text-sm">
+          <span className="text-muted-foreground">Роль</span>
+          <select
+            value={form.role}
+            onChange={(e) => setForm((prev) => ({ ...prev, role: e.target.value as UserEditValues["role"] }))}
+            className="w-full rounded-lg border bg-background px-3 py-2"
+          >
+            {ROLES.map((role) => (
+              <option key={role} value={role}>
+                {role}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="space-y-1 text-sm">
+          <span className="text-muted-foreground">Статус</span>
+          <select
+            value={form.status}
+            onChange={(e) => setForm((prev) => ({ ...prev, status: e.target.value as "active" | "blocked" }))}
+            className="w-full rounded-lg border bg-background px-3 py-2"
+          >
+            <option value="active">active</option>
+            <option value="blocked">blocked</option>
+          </select>
+        </label>
+      </div>
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="inline-flex items-center rounded-lg bg-primary text-primary-foreground px-4 py-2 text-sm font-medium disabled:opacity-60"
+      >
+        {isPending ? "Сохранение..." : "Сохранить изменения"}
+      </button>
+    </form>
+  );
+}

--- a/lib/actions/admin.ts
+++ b/lib/actions/admin.ts
@@ -58,6 +58,49 @@ export async function updateUserStatusAction(userId: string, status: "active" | 
   return { success: true };
 }
 
+const updateUserProfileSchema = z.object({
+  first_name: z.string().trim().min(1, "Имя обязательно"),
+  last_name: z.string().trim().min(1, "Фамилия обязательна"),
+  phone: z.string().trim().optional(),
+  city: z.string().trim().optional(),
+  country: z.string().trim().optional(),
+  role: z.enum(["user", "client", "trainer", "admin"]),
+  status: z.enum(["active", "blocked"]),
+});
+
+export async function updateUserProfileAdminAction(
+  userId: string,
+  data: z.infer<typeof updateUserProfileSchema>
+) {
+  const { user: adminUser } = await requireAdmin();
+  const parsed = updateUserProfileSchema.safeParse(data);
+  if (!parsed.success) {
+    return { error: parsed.error.errors[0]?.message ?? "Некорректные данные" };
+  }
+
+  if (userId === adminUser.id && parsed.data.role !== "admin") {
+    return { error: "Вы не можете снять с себя роль администратора" };
+  }
+
+  const adminDb = createAdminClient();
+  const payload = {
+    first_name: parsed.data.first_name,
+    last_name: parsed.data.last_name,
+    phone: parsed.data.phone || null,
+    city: parsed.data.city || null,
+    country: parsed.data.country || null,
+    role: parsed.data.role,
+    status: parsed.data.status,
+  };
+
+  const { error } = await adminDb.from("users_profile").update(payload).eq("id", userId);
+  if (error) return { error: error.message };
+
+  revalidatePath("/admin/users");
+  revalidatePath(`/admin/users/${userId}`);
+  return { success: true };
+}
+
 // --- SESSION TYPES ---
 const sessionTypeSchema = z.object({
   title: z.string().min(1),


### PR DESCRIPTION
Refs #50

## Что сделано
- исправлен 404 на странице `/admin/users/[id]`: чтение профиля и бронирований переведено на service-role клиент (`createAdminClient`) вместо обычного клиента с RLS;
- добавлена форма редактирования пользователя на странице деталей админки;
- добавлен новый server action `updateUserProfileAdminAction` с валидацией и revalidate для списка/деталей пользователя.

## Изменённые файлы
- app/admin/users/[id]/page.tsx
- app/admin/users/[id]/user-edit-form.tsx
- lib/actions/admin.ts

## Проверка
- Type diagnostics в изменённых файлах: без ошибок.
- `pnpm exec tsc --noEmit` после фикса типов: ошибок не выявлено.