### PR TITLE
feat(theme): сохранять тему пользователя в БД и применять после входа

### DIFF
--- a/app/(user)/profile/settings/settings-client.tsx
+++ b/app/(user)/profile/settings/settings-client.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { useTheme } from "next-themes";
 import { createClient } from "@/lib/supabase/client";
+import { updateUserThemePreferenceAction, type ThemePreference } from "@/lib/actions/user";
 import { useRouter } from "next/navigation";
 import {
   Shield, Moon, Sun, Monitor, LogOut, Trash2, ChevronRight, Mail, User, Lock
@@ -30,6 +31,14 @@ export function SettingsClient({ email, profile }: SettingsClientProps) {
   const { theme, setTheme } = useTheme();
   const router = useRouter();
   const [isSigningOut, setIsSigningOut] = useState(false);
+
+  const applyTheme = async (value: ThemePreference) => {
+    setTheme(value);
+    const result = await updateUserThemePreferenceAction(value);
+    if (result?.error) {
+      toast.error("Не удалось сохранить тему", { description: result.error });
+    }
+  };
 
   const handleSignOut = async () => {
     setIsSigningOut(true);
@@ -105,7 +114,7 @@ export function SettingsClient({ email, profile }: SettingsClientProps) {
           {themeOptions.map(({ value, label, icon: Icon }) => (
             <button
               key={value}
-              onClick={() => setTheme(value)}
+              onClick={() => void applyTheme(value as ThemePreference)}
               className={`flex flex-col items-center gap-2 p-4 rounded-2xl border-2 text-sm font-medium transition-all ${
                 theme === value
                   ? "border-primary bg-primary/5 text-primary"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata, Viewport } from 'next'
 import { Analytics } from '@vercel/analytics/next'
 import { ThemeProvider } from '@/components/theme-provider'
+import { ThemePreferenceSync } from '@/components/global/theme-preference-sync'
 import { Toaster } from '@/components/ui/sonner'
+import { createClient } from '@/lib/supabase/server'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -31,20 +33,46 @@ export const viewport: Viewport = {
   ],
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  let userPreferredTheme: 'light' | 'dark' | 'system' | null = null
+
+  if (user) {
+    const { data } = await supabase
+      .from('users_profile')
+      .select('theme_preference')
+      .eq('id', user.id)
+      .single()
+
+    if (
+      data?.theme_preference === 'light' ||
+      data?.theme_preference === 'dark' ||
+      data?.theme_preference === 'system'
+    ) {
+      userPreferredTheme = data.theme_preference
+    }
+  }
+
+  const initialTheme = userPreferredTheme ?? 'light'
+
   return (
     <html lang="ru" suppressHydrationWarning>
       <body className="font-sans antialiased">
         <ThemeProvider
           attribute="class"
-          defaultTheme="light"
+          defaultTheme={initialTheme}
           enableSystem
           disableTransitionOnChange
         >
+          <ThemePreferenceSync preferredTheme={userPreferredTheme} />
           {children}
         </ThemeProvider>
         <Toaster />

--- a/components/global/theme-preference-sync.tsx
+++ b/components/global/theme-preference-sync.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useEffect } from "react"
+import { useTheme } from "next-themes"
+import type { ThemePreference } from "@/lib/actions/user"
+
+export function ThemePreferenceSync({ preferredTheme }: { preferredTheme: ThemePreference | null }) {
+  const { theme, setTheme } = useTheme()
+
+  useEffect(() => {
+    if (!preferredTheme) return
+    if (theme === preferredTheme) return
+    setTheme(preferredTheme)
+  }, [preferredTheme, setTheme, theme])
+
+  return null
+}

--- a/components/global/theme-preference-sync.tsx
+++ b/components/global/theme-preference-sync.tsx
@@ -3,7 +3,12 @@
 import { useEffect } from "react"
 import { usePathname } from "next/navigation"
 import { useTheme } from "next-themes"
-import { getCurrentUserThemePreferenceAction, type ThemePreference } from "@/lib/actions/user"
+import { createClient } from "@/lib/supabase/client"
+import type { ThemePreference } from "@/lib/actions/user"
+
+function isThemePreference(value: string): value is ThemePreference {
+  return value === "light" || value === "dark" || value === "system"
+}
 
 export function ThemePreferenceSync({ preferredTheme }: { preferredTheme: ThemePreference | null }) {
   const { theme, setTheme } = useTheme()
@@ -19,8 +24,21 @@ export function ThemePreferenceSync({ preferredTheme }: { preferredTheme: ThemeP
     let isActive = true
 
     const syncFromServer = async () => {
-      const serverTheme = await getCurrentUserThemePreferenceAction()
-      if (!isActive || !serverTheme) return
+      const supabase = createClient()
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+
+      if (!isActive || !user) return
+
+      const { data } = await supabase
+        .from("users_profile")
+        .select("theme_preference")
+        .eq("id", user.id)
+        .single()
+
+      const serverTheme = data?.theme_preference
+      if (!isActive || typeof serverTheme !== "string" || !isThemePreference(serverTheme)) return
       if (theme === serverTheme) return
       setTheme(serverTheme)
     }

--- a/components/global/theme-preference-sync.tsx
+++ b/components/global/theme-preference-sync.tsx
@@ -1,17 +1,36 @@
 "use client"
 
 import { useEffect } from "react"
+import { usePathname } from "next/navigation"
 import { useTheme } from "next-themes"
-import type { ThemePreference } from "@/lib/actions/user"
+import { getCurrentUserThemePreferenceAction, type ThemePreference } from "@/lib/actions/user"
 
 export function ThemePreferenceSync({ preferredTheme }: { preferredTheme: ThemePreference | null }) {
   const { theme, setTheme } = useTheme()
+  const pathname = usePathname()
 
   useEffect(() => {
     if (!preferredTheme) return
     if (theme === preferredTheme) return
     setTheme(preferredTheme)
   }, [preferredTheme, setTheme, theme])
+
+  useEffect(() => {
+    let isActive = true
+
+    const syncFromServer = async () => {
+      const serverTheme = await getCurrentUserThemePreferenceAction()
+      if (!isActive || !serverTheme) return
+      if (theme === serverTheme) return
+      setTheme(serverTheme)
+    }
+
+    void syncFromServer()
+
+    return () => {
+      isActive = false
+    }
+  }, [pathname, setTheme, theme])
 
   return null
 }

--- a/components/global/theme-preference-sync.tsx
+++ b/components/global/theme-preference-sync.tsx
@@ -13,6 +13,7 @@ function isThemePreference(value: string): value is ThemePreference {
 export function ThemePreferenceSync({ preferredTheme }: { preferredTheme: ThemePreference | null }) {
   const { theme, setTheme } = useTheme()
   const pathname = usePathname()
+  const supabase = createClient()
 
   useEffect(() => {
     if (!preferredTheme) return
@@ -24,7 +25,6 @@ export function ThemePreferenceSync({ preferredTheme }: { preferredTheme: ThemeP
     let isActive = true
 
     const syncFromServer = async () => {
-      const supabase = createClient()
       const {
         data: { user },
       } = await supabase.auth.getUser()
@@ -45,10 +45,22 @@ export function ThemePreferenceSync({ preferredTheme }: { preferredTheme: ThemeP
 
     void syncFromServer()
 
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event) => {
+      if (event === "SIGNED_IN" || event === "INITIAL_SESSION" || event === "TOKEN_REFRESHED") {
+        void syncFromServer()
+      }
+      if (event === "SIGNED_OUT") {
+        setTheme("light")
+      }
+    })
+
     return () => {
       isActive = false
+      subscription.unsubscribe()
     }
-  }, [pathname, setTheme, theme])
+  }, [pathname, setTheme, theme, supabase])
 
   return null
 }

--- a/components/global/theme-toggle.tsx
+++ b/components/global/theme-toggle.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { Moon, Sun } from "lucide-react"
 import { useTheme } from "next-themes"
+import { updateUserThemePreferenceAction, type ThemePreference } from "@/lib/actions/user"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -15,6 +16,11 @@ import {
 export function ThemeToggle() {
   const { setTheme, theme } = useTheme()
 
+  const applyTheme = (value: ThemePreference) => {
+    setTheme(value)
+    void updateUserThemePreferenceAction(value)
+  }
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
@@ -25,13 +31,13 @@ export function ThemeToggle() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setTheme("light")}>
+        <DropdownMenuItem onClick={() => applyTheme("light")}>
           Светлая
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("dark")}>
+        <DropdownMenuItem onClick={() => applyTheme("dark")}>
           Темная
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("system")}>
+        <DropdownMenuItem onClick={() => applyTheme("system")}>
           Как в системе
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/components/shared/theme-toggle.tsx
+++ b/components/shared/theme-toggle.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
+import { updateUserThemePreferenceAction } from '@/lib/actions/user'
 import { Button } from '@/components/ui/button'
 
 export function ThemeToggle() {
@@ -26,7 +27,11 @@ export function ThemeToggle() {
       variant="ghost"
       size="icon"
       className="h-9 w-9"
-      onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+      onClick={() => {
+        const nextTheme = theme === 'light' ? 'dark' : 'light'
+        setTheme(nextTheme)
+        void updateUserThemePreferenceAction(nextTheme)
+      }}
     >
       <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />

--- a/lib/actions/user.ts
+++ b/lib/actions/user.ts
@@ -2,6 +2,13 @@
 
 import { createClient } from "@/lib/supabase/server"
 
+export const THEME_PREFERENCES = ["light", "dark", "system"] as const
+export type ThemePreference = (typeof THEME_PREFERENCES)[number]
+
+function isThemePreference(value: string): value is ThemePreference {
+  return THEME_PREFERENCES.includes(value as ThemePreference)
+}
+
 /**
  * Returns the current user's role and booking count.
  * Used for UI visibility logic (e.g., hiding trial booking buttons).
@@ -36,4 +43,52 @@ export async function getUserStatusAction() {
     role: profileResult.data?.role || "user",
     bookingCount: bookingsResult.count || 0
   }
+}
+
+export async function getCurrentUserThemePreferenceAction(): Promise<ThemePreference | null> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return null
+
+  const { data } = await supabase
+    .from("users_profile")
+    .select("theme_preference")
+    .eq("id", user.id)
+    .single()
+
+  const themePreference = data?.theme_preference
+  if (typeof themePreference !== "string" || !isThemePreference(themePreference)) {
+    return null
+  }
+
+  return themePreference
+}
+
+export async function updateUserThemePreferenceAction(theme: ThemePreference) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { error: "Пользователь не авторизован" }
+  }
+
+  if (!isThemePreference(theme)) {
+    return { error: "Недопустимое значение темы" }
+  }
+
+  const { error } = await supabase
+    .from("users_profile")
+    .update({ theme_preference: theme })
+    .eq("id", user.id)
+
+  if (error) {
+    return { error: error.message }
+  }
+
+  return { success: true }
 }

--- a/supabase/migrations/0001_user_theme_preference.sql
+++ b/supabase/migrations/0001_user_theme_preference.sql
@@ -1,0 +1,10 @@
+-- Persist user theme preference and keep values constrained.
+ALTER TABLE public.users_profile
+ADD COLUMN IF NOT EXISTS theme_preference TEXT NOT NULL DEFAULT 'system';
+
+ALTER TABLE public.users_profile
+DROP CONSTRAINT IF EXISTS users_profile_theme_preference_check;
+
+ALTER TABLE public.users_profile
+ADD CONSTRAINT users_profile_theme_preference_check
+CHECK (theme_preference IN ('light', 'dark', 'system'));


### PR DESCRIPTION
Refs #53

## Что сделано
- добавлено хранение `theme_preference` в `users_profile` через миграцию;
- добавлены server actions: чтение текущей темы пользователя и сохранение выбранной темы;
- обновлен root layout: если пользователь авторизован, тема читается из БД и используется как начальная;
- добавлен `ThemePreferenceSync`, который синхронизирует тему после входа и предотвращает рассинхрон с localStorage;
- обновлены переключатели темы и настройки профиля: при изменении темы значение сохраняется в БД.

## Измененные файлы
- app/layout.tsx
- lib/actions/user.ts
- components/global/theme-toggle.tsx
- components/shared/theme-toggle.tsx
- app/(user)/profile/settings/settings-client.tsx
- components/global/theme-preference-sync.tsx
- supabase/migrations/0001_user_theme_preference.sql

## Проверка
- diagnostics в измененных файлах: без ошибок;
- `pnpm exec tsc --noEmit`: ошибок типов не выявлено.