### PR TITLE
fix(profile): запретить blocked пользователю доступ к профилю

### DIFF
--- a/app/(user)/profile/blocked-profile-banner.tsx
+++ b/app/(user)/profile/blocked-profile-banner.tsx
@@ -1,0 +1,24 @@
+import { ShieldAlert } from "lucide-react"
+
+export function BlockedProfileBanner() {
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="rounded-3xl border border-destructive/30 bg-destructive/5 p-8 shadow-sm">
+        <div className="flex items-start gap-4">
+          <div className="p-3 rounded-2xl bg-destructive/10 text-destructive">
+            <ShieldAlert className="w-6 h-6" />
+          </div>
+          <div className="space-y-3">
+            <h1 className="text-2xl font-bold tracking-tight text-destructive">Доступ к профилю ограничен</h1>
+            <p className="text-sm text-foreground/80 leading-relaxed">
+              Ваш аккаунт временно заблокирован. Просмотр и редактирование раздела профиля недоступны.
+            </p>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Если вы считаете, что это ошибка, обратитесь к администратору студии для уточнения причины и разблокировки.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/(user)/profile/edit/page.tsx
+++ b/app/(user)/profile/edit/page.tsx
@@ -19,6 +19,7 @@ export default async function EditProfilePage() {
     .single();
 
   if (!profile) redirect("/profile");
+  if (profile.status === "blocked") redirect("/profile");
 
   return (
     <div className="min-h-screen">

--- a/app/(user)/profile/page.tsx
+++ b/app/(user)/profile/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
 import { ProfileDashboard } from "./profile-dashboard"
+import { BlockedProfileBanner } from "./blocked-profile-banner"
 
 export default async function UserProfile() {
   const supabase = await createClient()
@@ -15,6 +16,10 @@ export default async function UserProfile() {
     .select('*')
     .eq('id', user.id)
     .single()
+
+  if (profile?.status === 'blocked') {
+    return <BlockedProfileBanner />
+  }
 
   // Admins and trainers can access the generic profile to edit their info and settings.
 

--- a/app/(user)/profile/settings/page.tsx
+++ b/app/(user)/profile/settings/page.tsx
@@ -12,9 +12,11 @@ export default async function SettingsPage() {
 
   const { data: profile } = await supabase
     .from("users_profile")
-    .select("email, first_name, last_name, role")
+    .select("email, first_name, last_name, role, status")
     .eq("id", user.id)
     .single();
+
+  if (profile?.status === "blocked") redirect("/profile");
 
   return (
     <div className="min-h-screen">


### PR DESCRIPTION
Refs #55

## Что сделано
- на `/profile` для `users_profile.status = blocked` показывается запрещающий баннер вместо обычного профиля;
- закрыт обход через `/profile/edit` и `/profile/settings` — для blocked выполняется редирект на `/profile`;
- для `active` пользователей поведение не изменено.

## Измененные файлы
- app/(user)/profile/blocked-profile-banner.tsx
- app/(user)/profile/page.tsx
- app/(user)/profile/edit/page.tsx
- app/(user)/profile/settings/page.tsx

## Проверка
- diagnostics в измененных файлах: без ошибок;
- `pnpm exec tsc --noEmit`: ошибок типов не выявлено.