### PR TITLE
Implement password recovery and email confirmation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ git checkout dev
 Пожалуйста, перед началом работы *внимательно* изучите: 
 👉 **[GITHUB_ISSUES_GUIDE.md](./GITHUB_ISSUES_GUIDE.md)**
 
+Для настройки подтверждения email и шаблонов писем Supabase:
+👉 **[AUTH_EMAIL_SETUP.md](./implementation/AUTH_EMAIL_SETUP.md)**
+
 Вкратце, разработчики и ИИ-агенты:
 1. Читают и заносят задачи через интегрированные `search_issues` / `list_issues`.
 2. Создают временную ветку под задачу: формата `feature/ID-title`, `bugfix/ID-title`, или `docs/ID-title` от базовой ветки `dev`.

--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -6,6 +6,20 @@ import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { z } from 'zod'
 
+function getSiteUrl() {
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+    process.env.VERCEL_URL
+
+  if (!siteUrl) {
+    return 'http://localhost:3000'
+  }
+
+  return siteUrl.startsWith('http') ? siteUrl : `https://${siteUrl}`
+}
+
 // Признак телефонного номера: только цифры, +, -, (), пробелы
 function isPhoneNumber(value: string): boolean {
   return /^[\d\s\+\-\(\)]{7,}$/.test(value.trim())
@@ -41,6 +55,14 @@ const signUpSchema = z.object({
   first_name: z.string().min(2, 'Имя должно содержать минимум 2 буквы'),
   last_name: z.string().min(2, 'Фамилия должна содержать минимум 2 буквы'),
   phone: z.string().min(10, 'Введите корректный номер телефона'),
+})
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email('Введите корректный email'),
+})
+
+const updatePasswordSchema = z.object({
+  password: z.string().min(6, 'Пароль должен содержать минимум 6 символов'),
 })
 
 export async function signInAction(formData: FormData) {
@@ -90,6 +112,7 @@ export async function signInAction(formData: FormData) {
 
 export async function signUpAction(formData: FormData) {
   const supabase = await createClient()
+  const siteUrl = getSiteUrl()
 
   const rawData = Object.fromEntries(formData)
   const validation = signUpSchema.safeParse(rawData)
@@ -103,6 +126,7 @@ export async function signUpAction(formData: FormData) {
     email: validation.data.email,
     password: validation.data.password,
     options: {
+      emailRedirectTo: `${siteUrl}/auth/callback?next=/profile`,
       data: {
         first_name: validation.data.first_name,
         last_name: validation.data.last_name,
@@ -115,12 +139,68 @@ export async function signUpAction(formData: FormData) {
     return { error: error.message }
   }
 
-  // Новый пользователь всегда идет в профиль
   revalidatePath('/', 'layout')
-  if (signUpData.user) {
+
+  // Если Supabase выдал сессию сразу, пользователь может зайти без подтверждения email.
+  if (signUpData.session && signUpData.user) {
     const redirectPath = await getRoleRedirectPath(signUpData.user.id)
     redirect(redirectPath)
-  } else {
-    redirect('/profile')
   }
+
+  return {
+    success: true,
+    message: 'Проверьте почту и подтвердите email, чтобы завершить регистрацию.',
+  }
+}
+
+export async function requestPasswordResetAction(formData: FormData) {
+  const supabase = await createClient()
+  const siteUrl = getSiteUrl()
+
+  const rawData = Object.fromEntries(formData)
+  const validation = forgotPasswordSchema.safeParse(rawData)
+
+  if (!validation.success) {
+    return { error: 'Введите корректный email' }
+  }
+
+  const { error } = await supabase.auth.resetPasswordForEmail(validation.data.email, {
+    redirectTo: `${siteUrl}/auth/callback?next=/reset-password`,
+  })
+
+  if (error) {
+    return { error: error.message }
+  }
+
+  return { success: true }
+}
+
+export async function updatePasswordAction(formData: FormData) {
+  const supabase = await createClient()
+
+  const rawData = Object.fromEntries(formData)
+  const validation = updatePasswordSchema.safeParse(rawData)
+
+  if (!validation.success) {
+    const firstError = validation.error.errors[0]?.message
+    return { error: firstError || 'Некорректный пароль' }
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { error: 'Сессия восстановления устарела. Повторите запрос на смену пароля.' }
+  }
+
+  const { error } = await supabase.auth.updateUser({
+    password: validation.data.password,
+  })
+
+  if (error) {
+    return { error: error.message }
+  }
+
+  return { success: true }
 }

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import * as z from 'zod'
+import { motion } from 'framer-motion'
+import { ArrowLeft, Loader2, Mail } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { requestPasswordResetAction } from '../actions'
+import { BrandLogo } from '@/components/shared/brand-logo'
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email('Введите корректный email'),
+})
+
+export default function ForgotPasswordPage() {
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<z.infer<typeof forgotPasswordSchema>>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: {
+      email: '',
+    },
+  })
+
+  function onSubmit(values: z.infer<typeof forgotPasswordSchema>) {
+    setError(null)
+    setSuccess(null)
+
+    startTransition(async () => {
+      const formData = new FormData()
+      formData.append('email', values.email)
+
+      const result = await requestPasswordResetAction(formData)
+      if (result?.error) {
+        setError(result.error)
+        toast.error('Не удалось отправить письмо', { description: result.error })
+        return
+      }
+
+      const message = 'Мы отправили письмо со ссылкой для сброса пароля.'
+      setSuccess(message)
+      toast.success('Письмо отправлено', { description: message })
+    })
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-8 bg-background relative">
+      <div className="absolute top-8 left-8 sm:top-10 sm:left-10">
+        <Link
+          href="/sign-in"
+          className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors group"
+        >
+          <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
+          Ко входу
+        </Link>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.35 }}
+        className="w-full max-w-[420px]"
+      >
+        <div className="text-center mb-8">
+          <div className="flex justify-center mb-5">
+            <BrandLogo />
+          </div>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">Забыли пароль?</h1>
+          <p className="text-sm text-muted-foreground mt-2">
+            Введите email, и мы отправим ссылку для восстановления доступа.
+          </p>
+        </div>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        placeholder="name@example.com"
+                        type="email"
+                        autoComplete="email"
+                        className="h-12 bg-muted/50 border-none focus-visible:ring-1 focus-visible:ring-primary/40 rounded-xl pl-11"
+                        {...field}
+                      />
+                      <Mail className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {error && (
+              <div className="text-sm font-medium text-destructive p-3 bg-destructive/10 rounded-xl">
+                {error}
+              </div>
+            )}
+
+            {success && (
+              <div className="text-sm font-medium text-emerald-700 dark:text-emerald-300 p-3 bg-emerald-500/10 rounded-xl">
+                {success}
+              </div>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full h-12 text-base rounded-xl hover:shadow-lg hover:shadow-primary/20 transition-all font-semibold"
+              disabled={isPending}
+            >
+              {isPending && <Loader2 className="mr-2 h-5 w-5 animate-spin" />}
+              Отправить ссылку
+            </Button>
+          </form>
+        </Form>
+      </motion.div>
+    </div>
+  )
+}

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import * as z from 'zod'
+import { motion } from 'framer-motion'
+import { ArrowLeft, Eye, EyeOff, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { updatePasswordAction } from '../actions'
+import { BrandLogo } from '@/components/shared/brand-logo'
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+const resetPasswordSchema = z
+  .object({
+    password: z.string().min(6, 'Пароль должен содержать минимум 6 символов'),
+    confirmPassword: z.string().min(6, 'Подтвердите пароль'),
+  })
+  .refine((values) => values.password === values.confirmPassword, {
+    message: 'Пароли не совпадают',
+    path: ['confirmPassword'],
+  })
+
+export default function ResetPasswordPage() {
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<z.infer<typeof resetPasswordSchema>>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: {
+      password: '',
+      confirmPassword: '',
+    },
+  })
+
+  function onSubmit(values: z.infer<typeof resetPasswordSchema>) {
+    setError(null)
+    setSuccess(null)
+
+    startTransition(async () => {
+      const formData = new FormData()
+      formData.append('password', values.password)
+
+      const result = await updatePasswordAction(formData)
+      if (result?.error) {
+        setError(result.error)
+        toast.error('Не удалось обновить пароль', { description: result.error })
+        return
+      }
+
+      const message = 'Пароль успешно обновлён. Теперь вы можете войти с новым паролем.'
+      setSuccess(message)
+      toast.success('Пароль обновлён', { description: message })
+      form.reset({ password: '', confirmPassword: '' })
+    })
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-8 bg-background relative">
+      <div className="absolute top-8 left-8 sm:top-10 sm:left-10">
+        <Link
+          href="/sign-in"
+          className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors group"
+        >
+          <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
+          Ко входу
+        </Link>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.35 }}
+        className="w-full max-w-[420px]"
+      >
+        <div className="text-center mb-8">
+          <div className="flex justify-center mb-5">
+            <BrandLogo />
+          </div>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">Новый пароль</h1>
+          <p className="text-sm text-muted-foreground mt-2">
+            Введите новый пароль для вашего аккаунта.
+          </p>
+        </div>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Новый пароль</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        placeholder="Минимум 6 символов"
+                        type={showPassword ? 'text' : 'password'}
+                        autoComplete="new-password"
+                        className="h-12 bg-muted/50 border-none focus-visible:ring-1 focus-visible:ring-primary/40 rounded-xl pr-12"
+                        {...field}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword((prev) => !prev)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 p-2 text-muted-foreground hover:text-foreground transition-colors"
+                        aria-label="Показать или скрыть пароль"
+                      >
+                        {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                      </button>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Подтвердите пароль</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        placeholder="Повторите пароль"
+                        type={showConfirmPassword ? 'text' : 'password'}
+                        autoComplete="new-password"
+                        className="h-12 bg-muted/50 border-none focus-visible:ring-1 focus-visible:ring-primary/40 rounded-xl pr-12"
+                        {...field}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowConfirmPassword((prev) => !prev)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 p-2 text-muted-foreground hover:text-foreground transition-colors"
+                        aria-label="Показать или скрыть подтверждение пароля"
+                      >
+                        {showConfirmPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                      </button>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {error && (
+              <div className="text-sm font-medium text-destructive p-3 bg-destructive/10 rounded-xl">
+                {error}
+              </div>
+            )}
+
+            {success && (
+              <div className="text-sm font-medium text-emerald-700 dark:text-emerald-300 p-3 bg-emerald-500/10 rounded-xl">
+                {success}{' '}
+                <Link href="/sign-in" className="underline underline-offset-4 font-semibold">
+                  Перейти ко входу
+                </Link>
+              </div>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full h-12 text-base rounded-xl hover:shadow-lg hover:shadow-primary/20 transition-all font-semibold"
+              disabled={isPending}
+            >
+              {isPending && <Loader2 className="mr-2 h-5 w-5 animate-spin" />}
+              Обновить пароль
+            </Button>
+          </form>
+        </Form>
+      </motion.div>
+    </div>
+  )
+}

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -194,7 +194,7 @@ export default function SignInPage() {
                       <div className="flex items-center justify-between">
                         <FormLabel>Пароль</FormLabel>
                         <Link
-                          href="#"
+                          href="/forgot-password"
                           className="text-sm font-medium text-primary hover:underline underline-offset-4"
                         >
                           Забыли пароль?

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -46,6 +46,7 @@ const itemVariants = {
 
 export default function SignUpPage() {
   const [error, setError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
   const [showPassword, setShowPassword] = useState(false)
 
@@ -62,6 +63,7 @@ export default function SignUpPage() {
 
   function onSubmit(values: z.infer<typeof signUpSchema>) {
     setError(null)
+    setSuccessMessage(null)
     startTransition(async () => {
       const formData = new FormData()
       Object.entries(values).forEach(([key, value]) => {
@@ -73,7 +75,16 @@ export default function SignUpPage() {
         setError(res.error)
         toast.error('Ошибка регистрации', { description: res.error })
       } else {
-        toast.success('Успешная регистрация', { description: 'Добро пожаловать в студию!' })
+        const message = res?.message ?? 'Проверьте почту для подтверждения регистрации.'
+        setSuccessMessage(message)
+        toast.success('Письмо отправлено', { description: message })
+        form.reset({
+          first_name: '',
+          last_name: '',
+          phone: '',
+          email: '',
+          password: '',
+        })
       }
     })
   }
@@ -208,6 +219,12 @@ export default function SignUpPage() {
               {error && (
                 <motion.div variants={itemVariants} className="text-sm font-medium text-destructive p-3 bg-destructive/10 rounded-lg">
                   {error}
+                </motion.div>
+              )}
+
+              {successMessage && (
+                <motion.div variants={itemVariants} className="text-sm font-medium text-emerald-700 dark:text-emerald-300 p-3 bg-emerald-500/10 rounded-lg">
+                  {successMessage}
                 </motion.div>
               )}
 

--- a/app/(user)/profile/settings/settings-client.tsx
+++ b/app/(user)/profile/settings/settings-client.tsx
@@ -67,7 +67,7 @@ export function SettingsClient({ email, profile }: SettingsClientProps) {
     });
     const supabase = createClient();
     supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}/auth/callback`,
+      redirectTo: `${window.location.origin}/auth/callback?next=/reset-password`,
     });
   };
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import type { EmailOtpType } from '@supabase/supabase-js'
+
+function getSafeNextPath(value: string | null) {
+  if (!value || !value.startsWith('/')) {
+    return '/profile'
+  }
+
+  return value
+}
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url)
+  const code = url.searchParams.get('code')
+  const tokenHash = url.searchParams.get('token_hash')
+  const type = url.searchParams.get('type') as EmailOtpType | null
+  const nextPath = getSafeNextPath(url.searchParams.get('next'))
+
+  const supabase = await createClient()
+
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (!error) {
+      return NextResponse.redirect(new URL(nextPath, url.origin))
+    }
+  }
+
+  if (tokenHash && type) {
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash: tokenHash,
+    })
+
+    if (!error) {
+      return NextResponse.redirect(new URL(nextPath, url.origin))
+    }
+  }
+
+  return NextResponse.redirect(new URL('/sign-in?error=auth_callback_failed', url.origin))
+}

--- a/implementation/AUTH_EMAIL_SETUP.md
+++ b/implementation/AUTH_EMAIL_SETUP.md
@@ -1,0 +1,84 @@
+# Auth Email Setup (Supabase)
+
+Этот документ описывает настройку подтверждения email и красивого шаблона письма для проекта.
+
+## 1. Обязательные URL в Supabase
+
+В Supabase Dashboard:
+- Authentication -> URL Configuration
+
+Установите:
+- Site URL: https://YOUR_PRODUCTION_DOMAIN
+- Redirect URLs: добавьте
+  - https://YOUR_PRODUCTION_DOMAIN/auth/callback
+  - http://localhost:3000/auth/callback (для локальной разработки)
+
+## 2. Redirect при регистрации
+
+В серверном действии регистрации используется:
+- emailRedirectTo: https://YOUR_PRODUCTION_DOMAIN/auth/callback?next=/profile
+
+Это гарантирует, что ссылка подтверждения почты не ведет на localhost в production.
+
+## 3. Шаблон письма подтверждения
+
+В Supabase Dashboard:
+- Authentication -> Email Templates -> Confirm signup
+
+Вставьте HTML ниже и проверьте, что переменная ссылки подтверждения используется как {{ .ConfirmationURL }}.
+
+```html
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Подтвердите email | Pilatta</title>
+  </head>
+  <body style="margin:0;padding:0;background:#f7f4ef;font-family:Arial,sans-serif;color:#2d2520;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="padding:24px 12px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border-radius:16px;overflow:hidden;border:1px solid #eadfce;">
+            <tr>
+              <td style="padding:28px 28px 20px;background:linear-gradient(135deg,#8a5a3d,#c29063);color:#fff;">
+                <h1 style="margin:0;font-size:24px;line-height:1.25;">Pilatta</h1>
+                <p style="margin:10px 0 0;font-size:14px;line-height:1.5;opacity:.95;">Подтвердите ваш email, чтобы завершить регистрацию</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:28px;">
+                <p style="margin:0 0 14px;font-size:15px;line-height:1.6;">Спасибо за регистрацию в студии Pilatta.</p>
+                <p style="margin:0 0 22px;font-size:15px;line-height:1.6;">Нажмите кнопку ниже, чтобы подтвердить email и активировать аккаунт.</p>
+
+                <table role="presentation" cellspacing="0" cellpadding="0" style="margin:0 0 22px;">
+                  <tr>
+                    <td>
+                      <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:12px 20px;border-radius:10px;background:#8a5a3d;color:#fff;text-decoration:none;font-size:14px;font-weight:bold;">Подтвердить email</a>
+                    </td>
+                  </tr>
+                </table>
+
+                <p style="margin:0 0 10px;font-size:13px;line-height:1.6;color:#6f5d52;">Если кнопка не работает, скопируйте и откройте ссылку:</p>
+                <p style="margin:0;word-break:break-all;font-size:12px;line-height:1.6;color:#8a5a3d;">{{ .ConfirmationURL }}</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 28px;background:#f9f5ee;border-top:1px solid #eadfce;color:#7a6a5d;font-size:12px;line-height:1.6;">
+                Это письмо отправлено автоматически. Если вы не создавали аккаунт, просто игнорируйте его.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+```
+
+## 4. Проверка
+
+1. Зарегистрируйте нового пользователя.
+2. Откройте письмо подтверждения и перейдите по ссылке.
+3. Проверьте, что редирект идет в production на /auth/callback и далее на /profile.
+4. Убедитесь, что страница не падает и пользователь видит корректный экран.

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -43,9 +43,14 @@ export async function updateSession(request: NextRequest) {
 
   const pathname = request.nextUrl.pathname
   const isAuthRoute = pathname.startsWith('/sign-in') || pathname.startsWith('/sign-up')
+  const isPublicAuthRoute =
+    isAuthRoute ||
+    pathname.startsWith('/forgot-password') ||
+    pathname.startsWith('/reset-password') ||
+    pathname.startsWith('/auth/callback')
 
   // Неавторизованный пользователь пытается зайти на защищённый маршрут
-  if (!user && !isAuthRoute && pathname !== '/') {
+  if (!user && !isPublicAuthRoute && pathname !== '/') {
     const url = request.nextUrl.clone()
     url.pathname = '/sign-in'
     return NextResponse.redirect(url)


### PR DESCRIPTION
Closes #61

Что сделано:
- добавлены страницы `forgot-password` и `reset-password`;
- добавлен callback route `app/auth/callback/route.ts` для корректной обработки подтверждения email и recovery ссылок;
- обновлен auth action регистрации: используется production-safe `emailRedirectTo` вместо fallback на localhost;
- обновлен sign-in: ссылка `Забыли пароль?` ведет на рабочую страницу;
- обновлен sign-up: после успешной регистрации показывается инструкция подтвердить email;
- обновлен middleware: добавлены публичные auth маршруты (`/forgot-password`, `/reset-password`, `/auth/callback`);
- обновлен reset flow из профиля с redirect в новый callback маршрут;
- добавлен документ с настройкой Supabase URL и кастомным шаблоном письма.

Примечание:
- кастомизация самого письма в Supabase выполняется в Dashboard; в PR добавлен готовый HTML-шаблон и инструкция.