### PR TITLE
Fix mobile profile access and menu CTA layout

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -161,11 +161,7 @@ export function Header({ initialUserStatus }: HeaderProps) {
               />
             </div>
             <div className="lg:hidden">
-              <MobileNav
-                navItems={navItems}
-                isAuthenticated={initialUserStatus?.isAuthenticated}
-                role={initialUserStatus?.role ?? null}
-              />
+              <MobileNav navItems={navItems} />
             </div>
           </div>
         </div>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -115,6 +115,21 @@ export function Header({ initialUserStatus }: HeaderProps) {
           {/* Right side */}
           <div className="flex items-center gap-3">
             <ThemeToggle />
+            {initialUserStatus?.isAuthenticated === true && (
+              <Button variant="outline" size="sm" asChild className="h-9 rounded-full px-4 lg:hidden">
+                <Link
+                  href={
+                    initialUserStatus.role === 'admin'
+                      ? '/admin/dashboard'
+                      : initialUserStatus.role === 'trainer'
+                        ? '/trainer/schedule'
+                        : '/profile'
+                  }
+                >
+                  Профиль
+                </Link>
+              </Button>
+            )}
             {initialUserStatus?.isAuthenticated === false && (
               <Button variant="outline" size="sm" asChild className="h-9 rounded-full px-4 lg:hidden">
                 <Link href="/sign-in">Войти</Link>
@@ -146,7 +161,11 @@ export function Header({ initialUserStatus }: HeaderProps) {
               />
             </div>
             <div className="lg:hidden">
-              <MobileNav navItems={navItems} isAuthenticated={initialUserStatus?.isAuthenticated} />
+              <MobileNav
+                navItems={navItems}
+                isAuthenticated={initialUserStatus?.isAuthenticated}
+                role={initialUserStatus?.role ?? null}
+              />
             </div>
           </div>
         </div>

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -22,9 +22,10 @@ interface NavItem {
 interface MobileNavProps {
   navItems: NavItem[]
   isAuthenticated?: boolean
+  role?: string | null
 }
 
-export function MobileNav({ navItems, isAuthenticated }: MobileNavProps) {
+export function MobileNav({ navItems, isAuthenticated, role = null }: MobileNavProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   const handleNavClick = (href: string) => {
@@ -45,26 +46,34 @@ export function MobileNav({ navItems, isAuthenticated }: MobileNavProps) {
           <span className="sr-only">Открыть меню</span>
         </Button>
       </SheetTrigger>
-      <SheetContent side="right" className="w-full max-w-sm bg-background border-l border-border">
+      <SheetContent side="right" className="w-full max-w-sm h-full bg-background border-l border-border">
         <SheetHeader className="text-left">
           <SheetTitle>
             <BrandLogo compact />
           </SheetTitle>
         </SheetHeader>
-        <nav className="mt-8 flex flex-col gap-2">
-          {navItems.map((item) => (
-            <button
-              key={item.href}
-              onClick={() => handleNavClick(item.href)}
-              className="text-left text-lg font-medium text-muted-foreground transition-all hover:text-foreground hover:bg-muted px-4 py-3 rounded-xl"
-            >
-              {item.label}
-            </button>
-          ))}
-          <div className="mt-6 pt-6 border-t border-border flex flex-col gap-2">
+        <nav className="mt-6 flex flex-1 flex-col min-h-0">
+          <div className="flex flex-col gap-2">
+            {navItems.map((item) => (
+              <button
+                key={item.href}
+                onClick={() => handleNavClick(item.href)}
+                className="text-left text-lg font-medium text-muted-foreground transition-all hover:text-foreground hover:bg-muted px-4 py-3 rounded-xl"
+              >
+                {item.label}
+              </button>
+            ))}
+
             {isAuthenticated && (
-              <AuthNav isMobile={true} className="w-full justify-start px-4 text-base font-medium" />
+              <AuthNav
+                isMobile={true}
+                className="w-full justify-start px-4 text-base font-medium"
+                initialAuthState={{ isAuthenticated: true, role }}
+              />
             )}
+          </div>
+
+          <div className="mt-auto pt-6 border-t border-border flex flex-col gap-2">
             <CTAButton className="w-full" size="lg" initialVisible onClick={() => setIsOpen(false)} />
           </div>
         </nav>

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Menu } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -11,7 +11,6 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 import { CTAButton } from '@/components/shared/cta-button'
-import { AuthNav } from '@/components/layout/auth-nav'
 import { BrandLogo } from '@/components/shared/brand-logo'
 
 interface NavItem {
@@ -21,12 +20,21 @@ interface NavItem {
 
 interface MobileNavProps {
   navItems: NavItem[]
-  isAuthenticated?: boolean
-  role?: string | null
 }
 
-export function MobileNav({ navItems, isAuthenticated, role = null }: MobileNavProps) {
+export function MobileNav({ navItems }: MobileNavProps) {
   const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const originalOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.body.style.overflow = originalOverflow
+    }
+  }, [isOpen])
 
   const handleNavClick = (href: string) => {
     setIsOpen(false)
@@ -46,14 +54,17 @@ export function MobileNav({ navItems, isAuthenticated, role = null }: MobileNavP
           <span className="sr-only">Открыть меню</span>
         </Button>
       </SheetTrigger>
-      <SheetContent side="right" className="w-full max-w-sm h-full bg-background border-l border-border">
+      <SheetContent
+        side="right"
+        className="w-full max-w-sm h-dvh bg-background border-l border-border overflow-hidden pb-[max(env(safe-area-inset-bottom),0.75rem)]"
+      >
         <SheetHeader className="text-left">
           <SheetTitle>
             <BrandLogo compact />
           </SheetTitle>
         </SheetHeader>
-        <nav className="mt-6 flex flex-1 flex-col min-h-0">
-          <div className="flex flex-col gap-2">
+        <nav className="mt-4 flex flex-1 flex-col min-h-0">
+          <div className="flex flex-col gap-2 overflow-y-auto px-1">
             {navItems.map((item) => (
               <button
                 key={item.href}
@@ -63,17 +74,9 @@ export function MobileNav({ navItems, isAuthenticated, role = null }: MobileNavP
                 {item.label}
               </button>
             ))}
-
-            {isAuthenticated && (
-              <AuthNav
-                isMobile={true}
-                className="w-full justify-start px-4 text-base font-medium"
-                initialAuthState={{ isAuthenticated: true, role }}
-              />
-            )}
           </div>
 
-          <div className="mt-auto pt-6 border-t border-border flex flex-col gap-2">
+          <div className="mt-auto px-4 pt-5 border-t border-border/70">
             <CTAButton className="w-full" size="lg" initialVisible onClick={() => setIsOpen(false)} />
           </div>
         </nav>


### PR DESCRIPTION
Closes #63

Что исправлено:
- добавлена мобильная кнопка `Профиль` в хедер (на месте кнопки входа для авторизованного пользователя);
- для гостей на том же месте остаётся кнопка `Войти`;
- устранен пустой подсвеченный контейнер в меню за счет корректной инициализации `AuthNav`;
- кнопка `Записаться на пробное` закреплена в нижней части мобильного меню.

Проверено:
- diagnostics по измененным файлам без ошибок.